### PR TITLE
Fix Windows Validation and Profile Truncation

### DIFF
--- a/claude-profile-init.ps1
+++ b/claude-profile-init.ps1
@@ -60,7 +60,6 @@ function claude-profile {
 
     # --- Parse $args manually ---
     $Command = if ($args.Count -gt 0) { $args[0] } else { $null }
-    $Rest = if ($args.Count -gt 1) { $args[1..($args.Count - 1)] } else { @() }
 
     # --- Helpers (nested functions, scoped to claude-profile) ---
 
@@ -102,13 +101,13 @@ function claude-profile {
 
     switch ($Command) {
         'use' {
-            $ArgName = if ($Rest.Count -gt 0) { $Rest[0] } else { $null }
+            $ArgName = if ($args.Count -gt 1) { $args[1] } else { $null }
             if ([string]::IsNullOrEmpty($ArgName)) {
                 _cp_die 'usage: claude-profile use <name>'
                 return
             }
-            if ($Rest.Count -gt 1) {
-                _cp_die "unexpected argument after profile name: '$($Rest[1])'"
+            if ($args.Count -gt 2) {
+                _cp_die "unexpected argument after profile name: '$($args[2])'"
                 return
             }
             if (-not (_cp_validate_name $ArgName)) { return }
@@ -122,7 +121,7 @@ function claude-profile {
         }
 
         'create' {
-            $ArgName = if ($Rest.Count -gt 0) { $Rest[0] } else { $null }
+            $ArgName = if ($args.Count -gt 1) { $args[1] } else { $null }
             if ([string]::IsNullOrEmpty($ArgName)) {
                 _cp_die 'usage: claude-profile create <name>'
                 return
@@ -177,7 +176,7 @@ function claude-profile {
         }
 
         'default' {
-            $ArgName = if ($Rest.Count -gt 0) { $Rest[0] } else { $null }
+            $ArgName = if ($args.Count -gt 1) { $args[1] } else { $null }
             if ([string]::IsNullOrEmpty($ArgName)) {
                 # Get default
                 if (Test-Path $DefaultFile) {
@@ -209,7 +208,7 @@ function claude-profile {
         }
 
         'which' {
-            $ArgName = if ($Rest.Count -gt 0) { $Rest[0] } else { $null }
+            $ArgName = if ($args.Count -gt 1) { $args[1] } else { $null }
             if (-not [string]::IsNullOrEmpty($ArgName)) {
                 # Named profile
                 if (-not (_cp_validate_name $ArgName)) { return }
@@ -240,7 +239,7 @@ function claude-profile {
         }
 
         'delete' {
-            $ArgName = if ($Rest.Count -gt 0) { $Rest[0] } else { $null }
+            $ArgName = if ($args.Count -gt 1) { $args[1] } else { $null }
             if ([string]::IsNullOrEmpty($ArgName)) {
                 _cp_die 'usage: claude-profile delete <name>'
                 return

--- a/claude-profile.cmd
+++ b/claude-profile.cmd
@@ -114,12 +114,7 @@ echo !_vn_name! | findstr /C:".." >nul 2>&1 && (
 )
 
 :: Check only valid characters (letters, digits, hyphens, underscores)
-:: Strip all valid characters; if anything remains, the name is invalid
-set "_vn_check=!_vn_name!"
-for %%c in (a b c d e f g h i j k l m n o p q r s t u v w x y z A B C D E F G H I J K L M N O P Q R S T U V W X Y Z 0 1 2 3 4 5 6 7 8 9 - _) do (
-    set "_vn_check=!_vn_check:%%c=!"
-)
-if not "!_vn_check!"=="" (
+echo !_vn_name!| findstr /R "^[a-zA-Z0-9_-][a-zA-Z0-9_-]*$" >nul 2>&1 || (
     echo claude-profile: invalid profile name '%_vn_name%': use only letters, digits, hyphens, underscores >&2
     exit /b 1
 )


### PR DESCRIPTION
  ## Problem
 1. **CMD Validation Error:** In `claude-profile.cmd`, names containing digits (like `test2`) were being incorrectly rejected due to a fragile character-stripping loop that failed in the Windows CMD environment.
 2. **PowerShell Name Truncation:** In `claude-profile-init.ps1`, a bug in argument parsing caused profile names to be truncated to their first character (e.g., `test` became `t`) when using certain subcommands.
 
 ## Solution
 1. **CMD:** Replaced the character-stripping loop with a robust `findstr` regex check (`^[a-zA-Z0-9_-][a-zA-Z0-9_-]*$`) for profile name validation.
 2. **PowerShell:** Fixed the manual argument parsing logic in the `claude-profile` function to correctly handle the full profile name instead of just the first character.