### PR TITLE
Add fish shell support and new profile commands (rename/clone/exec/show/edit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,14 @@ claude -p "explain this code"
 | `claude-profile default [name]` | Get or set the default profile |
 | `claude-profile delete <name>` | Delete a profile (with confirmation) |
 | `claude-profile which [name]` | Show the config directory path |
+| `claude-profile rename <old> <new>` | Rename a profile (follows default/active pointers) |
+| `claude-profile clone <src> <dst>` | Duplicate a profile, including its config |
+| `claude-profile exec <name> [--] [args]` | Run `claude` with a profile once, without switching |
+| `claude-profile show [name]` | Print a profile's `settings.json` (default profile if omitted) |
+| `claude-profile edit [name]` | Open a profile's `settings.json` in `$VISUAL`/`$EDITOR` |
 | `claude-profile help` | Show help |
+
+Tab-completion of subcommands and profile names is available in bash, zsh, and fish.
 
 ## How It Works
 
@@ -93,8 +100,13 @@ Profile names can contain letters, digits, hyphens, and underscores. Examples: `
 | Script | Platform | Shell |
 |--------|----------|-------|
 | `claude-profile.sh` | Linux, macOS, WSL, Git Bash / MSYS2 | bash, zsh (sourced) |
+| `claude-profile.fish` | Linux, macOS, WSL | fish (sourced) |
 | `claude-profile-init.ps1` | Windows, Linux, macOS | PowerShell 5.1+ / pwsh 6+ (dot-sourced) |
 | `claude-profile.cmd` | Windows | cmd.exe (use with `call` prefix) |
+
+### fish Support
+
+fish is not POSIX-compatible, so it cannot source `claude-profile.sh`. `claude-profile.fish` is a native fish port with the same commands and the same on-disk profile layout, so profiles created from bash/zsh are visible in fish and vice versa. The installer detects fish and sources the fish version from `config.fish` automatically. (Git Bash / MSYS2 path handling is bash/zsh-only; fish is not available on those platforms.)
 
 ### Git Bash / MSYS2 Support
 
@@ -120,6 +132,18 @@ curl -fsSL https://raw.githubusercontent.com/pegasusheavy/claude-code-profiles/m
 
 # Add to shell profile (.bashrc or .zshrc)
 echo '. "${XDG_DATA_HOME:-$HOME/.local/share}/claude-profile/claude-profile.sh"' >> ~/.bashrc
+```
+
+**fish:**
+
+```fish
+# Download
+mkdir -p "$HOME/.local/share/claude-profile"
+curl -fsSL https://raw.githubusercontent.com/pegasusheavy/claude-code-profiles/main/claude-profile.fish \
+  -o "$HOME/.local/share/claude-profile/claude-profile.fish"
+
+# Add to fish config
+echo 'source "$HOME/.local/share/claude-profile/claude-profile.fish"' >> ~/.config/fish/config.fish
 ```
 
 **Windows (PowerShell):**

--- a/claude-profile.fish
+++ b/claude-profile.fish
@@ -1,0 +1,499 @@
+# claude-profile.fish — Source this in ~/.config/fish/config.fish
+#
+#   source "$HOME/.local/share/claude-profile/claude-profile.fish"
+#
+# Native fish port of claude-profile.sh. Fish is NOT POSIX-compatible, so the
+# .sh file cannot be sourced here — it fails at parse time. This file is the
+# fish equivalent and shares the same on-disk profile layout, so profiles
+# created from bash/zsh are visible here and vice versa.
+#
+# Provides:
+#   claude           — runs Claude Code with the active/default profile
+#   claude-profile   — manage profiles (use, create, list, default, which,
+#                      delete, rename, clone, exec, show, edit)
+#
+# Supported on Linux, macOS, and WSL. (Fish does not run under Git Bash/MSYS,
+# so the cygpath handling from the POSIX version is intentionally omitted.)
+
+# --- Internal helpers ---
+
+function _cp_die --description 'Print a claude-profile error to stderr'
+    printf 'claude-profile: %s\n' "$argv[1]" >&2
+end
+
+# Resolves the profile data directory, matching the POSIX implementation's
+# $XDG_DATA_HOME/claude-profiles (default ~/.local/share/claude-profiles).
+function _cp_data_dir --description 'Resolve the claude-profile data directory'
+    if set -q XDG_DATA_HOME; and test -n "$XDG_DATA_HOME"
+        printf '%s\n' "$XDG_DATA_HOME/claude-profiles"
+    else
+        printf '%s\n' "$HOME/.local/share/claude-profiles"
+    end
+end
+
+function _cp_validate_name --description 'Validate a profile name (mirrors the POSIX rules)'
+    set -l name $argv[1]
+    if test -z "$name"
+        _cp_die "profile name must not be empty"
+        return 1
+    end
+    if string match -rq '^\.' -- $name
+        _cp_die "invalid profile name '$name': must not start with '.'"
+        return 1
+    end
+    if string match -q '*..*' -- $name
+        _cp_die "invalid profile name '$name': must not contain '..'"
+        return 1
+    end
+    if string match -q '*/*' -- $name
+        _cp_die "invalid profile name '$name': must not contain '/'"
+        return 1
+    end
+    if string match -q '*\\\\*' -- $name
+        _cp_die "invalid profile name '$name': must not contain '\\'"
+        return 1
+    end
+    if string match -rq '[^A-Za-z0-9_-]' -- $name
+        _cp_die "invalid profile name '$name': use only letters, digits, hyphens, underscores"
+        return 1
+    end
+    return 0
+end
+
+# Resolves a profile name to its directory, erroring if it does not exist.
+# Echoes the directory on success.
+function _cp_require_profile --description 'Validate a name and require its directory to exist'
+    set -l name $argv[1]
+    _cp_validate_name "$name"; or return 1
+    set -l dir (_cp_data_dir)/$name
+    if not test -d "$dir"
+        _cp_die "profile '$name' does not exist. Create it with: claude-profile create $name"
+        return 1
+    end
+    printf '%s\n' "$dir"
+end
+
+# Derives the managed-profile name from CLAUDE_CONFIG_DIR, if it points inside
+# the data directory. Echoes nothing when no managed profile is active.
+function _cp_active_name --description 'Echo the active managed profile name, if any'
+    set -q CLAUDE_CONFIG_DIR; or return 0
+    test -n "$CLAUDE_CONFIG_DIR"; or return 0
+    set -l data (_cp_data_dir)
+    if string match -q "$data/*" -- $CLAUDE_CONFIG_DIR
+        basename "$CLAUDE_CONFIG_DIR"
+    end
+end
+
+# --- claude() wrapper ---
+# Auto-resolves the default profile before calling the real claude binary.
+# If CLAUDE_CONFIG_DIR is already set (e.g. via 'claude-profile use'), it
+# passes through without overriding.
+
+function claude --description 'Run Claude Code with the active/default profile'
+    if not set -q CLAUDE_CONFIG_DIR; or test -z "$CLAUDE_CONFIG_DIR"
+        set -l data (_cp_data_dir)
+        set -l deffile "$data/.default"
+        if test -f "$deffile"
+            set -l name (cat "$deffile")
+            if test -n "$name"; and test -d "$data/$name"
+                set -gx CLAUDE_CONFIG_DIR "$data/$name"
+            end
+        end
+    end
+    command claude $argv
+end
+
+# --- claude-profile() management function ---
+
+function claude-profile --description 'Manage Claude Code profiles'
+    set -l data (_cp_data_dir)
+    set -l default_file "$data/.default"
+    set -l cmd $argv[1]
+    # Remaining args after the subcommand.
+    set -l rest $argv[2..-1]
+
+    switch "$cmd"
+        case use
+            set -l name $rest[1]
+            if test -z "$name"
+                _cp_die "usage: claude-profile use <name>"
+                return 1
+            end
+            if test (count $rest) -gt 1
+                _cp_die "unexpected argument after profile name: '$rest[2]'"
+                return 1
+            end
+            set -l dir (_cp_require_profile "$name"); or return 1
+            set -gx CLAUDE_CONFIG_DIR "$dir"
+            printf 'Switched to profile: %s\n' "$name"
+
+        case create
+            set -l do_init 0
+            set -l name ""
+            for arg in $rest
+                switch "$arg"
+                    case --init
+                        set do_init 1
+                    case '-*'
+                        _cp_die "unknown option '$arg'"
+                        return 1
+                    case '*'
+                        if test -n "$name"
+                            _cp_die "unexpected argument '$arg'"
+                            return 1
+                        end
+                        set name "$arg"
+                end
+            end
+            if test -z "$name"
+                _cp_die "usage: claude-profile create [--init] <name>"
+                return 1
+            end
+            _cp_validate_name "$name"; or return 1
+            set -l dir "$data/$name"
+            if test -d "$dir"
+                _cp_die "profile '$name' already exists"
+                return 1
+            end
+            mkdir -p "$dir"; or return 1
+            printf 'Created profile: %s\n' "$name"
+            printf 'Config directory: %s\n' "$dir"
+            if test "$do_init" -eq 1
+                set -l settings "$dir/settings.json"
+                _cp_write_skeleton "$settings"
+                printf 'Config skeleton written to: %s\n' "$settings"
+                printf 'Tip: remove "ANTHROPIC_BASE_URL" if using the default Anthropic endpoint.\n'
+                if set -q VISUAL; and test -n "$VISUAL"
+                    eval $VISUAL "$settings"
+                else if set -q EDITOR; and test -n "$EDITOR"
+                    eval $EDITOR "$settings"
+                end
+            end
+
+        case list ls
+            if not test -d "$data"
+                printf 'No profiles found. Create one with: claude-profile create <name>\n'
+                return 0
+            end
+            set -l cur_default ""
+            if test -f "$default_file"
+                set cur_default (cat "$default_file")
+            end
+            set -l active (_cp_active_name)
+            set -l found 0
+            for entry in "$data"/*/
+                test -d "$entry"; or continue
+                set -l name (basename "$entry")
+                set found 1
+                set -l is_default 0
+                set -l is_active 0
+                test "$name" = "$cur_default"; and set is_default 1
+                test "$name" = "$active"; and set is_active 1
+                if test "$is_default" -eq 1; and test "$is_active" -eq 1
+                    printf '>* %s (default, active)\n' "$name"
+                else if test "$is_default" -eq 1
+                    printf ' * %s (default)\n' "$name"
+                else if test "$is_active" -eq 1
+                    printf '>  %s (active)\n' "$name"
+                else
+                    printf '   %s\n' "$name"
+                end
+            end
+            if test "$found" -eq 0
+                printf 'No profiles found. Create one with: claude-profile create <name>\n'
+            end
+
+        case default
+            set -l name $rest[1]
+            if test -z "$name"
+                if test -f "$default_file"
+                    set -l cur (cat "$default_file")
+                    if test -n "$cur"
+                        printf '%s\n' "$cur"
+                    else
+                        _cp_die "default profile file is empty. Set one with: claude-profile default <name>"
+                        return 1
+                    end
+                else
+                    _cp_die "no default profile set. Set one with: claude-profile default <name>"
+                    return 1
+                end
+                return 0
+            end
+            _cp_require_profile "$name" >/dev/null; or return 1
+            mkdir -p "$data"; or return 1
+            printf '%s' "$name" >"$default_file"
+            printf 'Default profile set to: %s\n' "$name"
+
+        case which
+            set -l name $rest[1]
+            if test -n "$name"
+                set -l dir (_cp_require_profile "$name"); or return 1
+                printf '%s\n' "$dir"
+            else
+                if not test -f "$default_file"
+                    _cp_die "no default profile set. Use: claude-profile default <name>"
+                    return 1
+                end
+                set -l cur (cat "$default_file")
+                if test -z "$cur"
+                    _cp_die "default profile file is empty. Set one with: claude-profile default <name>"
+                    return 1
+                end
+                set -l dir (_cp_require_profile "$cur"); or return 1
+                printf '%s\n' "$dir"
+            end
+
+        case delete rm
+            set -l name $rest[1]
+            if test -z "$name"
+                _cp_die "usage: claude-profile delete <name>"
+                return 1
+            end
+            _cp_validate_name "$name"; or return 1
+            set -l dir "$data/$name"
+            if not test -d "$dir"
+                _cp_die "profile '$name' does not exist"
+                return 1
+            end
+            read -l -P "Delete profile \"$name\" and all its data? [y/N] " confirm
+            switch "$confirm"
+                case y Y yes YES Yes
+                    rm -rf "$dir"
+                    printf 'Deleted profile: %s\n' "$name"
+                    if test -f "$default_file"
+                        set -l cur (cat "$default_file")
+                        if test "$cur" = "$name"
+                            rm -f "$default_file"
+                            printf 'Cleared default profile (was "%s")\n' "$name"
+                        end
+                    end
+                    if set -q CLAUDE_CONFIG_DIR; and test "$CLAUDE_CONFIG_DIR" = "$dir"
+                        set -e CLAUDE_CONFIG_DIR
+                        printf 'Cleared active profile (was "%s")\n' "$name"
+                    end
+                case '*'
+                    printf 'Cancelled.\n'
+            end
+
+        case rename mv
+            set -l old $rest[1]
+            set -l new $rest[2]
+            if test -z "$old"; or test -z "$new"
+                _cp_die "usage: claude-profile rename <old> <new>"
+                return 1
+            end
+            if test (count $rest) -gt 2
+                _cp_die "unexpected argument: '$rest[3]'"
+                return 1
+            end
+            set -l old_dir (_cp_require_profile "$old"); or return 1
+            _cp_validate_name "$new"; or return 1
+            set -l new_dir "$data/$new"
+            if test -d "$new_dir"
+                _cp_die "profile '$new' already exists"
+                return 1
+            end
+            mv "$old_dir" "$new_dir"; or return 1
+            printf 'Renamed profile: %s -> %s\n' "$old" "$new"
+            # Follow the rename through default and active pointers.
+            if test -f "$default_file"; and test (cat "$default_file") = "$old"
+                printf '%s' "$new" >"$default_file"
+                printf 'Updated default profile to: %s\n' "$new"
+            end
+            if set -q CLAUDE_CONFIG_DIR; and test "$CLAUDE_CONFIG_DIR" = "$old_dir"
+                set -gx CLAUDE_CONFIG_DIR "$new_dir"
+                printf 'Updated active profile to: %s\n' "$new"
+            end
+
+        case clone copy cp
+            set -l src $rest[1]
+            set -l dst $rest[2]
+            if test -z "$src"; or test -z "$dst"
+                _cp_die "usage: claude-profile clone <source> <dest>"
+                return 1
+            end
+            if test (count $rest) -gt 2
+                _cp_die "unexpected argument: '$rest[3]'"
+                return 1
+            end
+            set -l src_dir (_cp_require_profile "$src"); or return 1
+            _cp_validate_name "$dst"; or return 1
+            set -l dst_dir "$data/$dst"
+            if test -d "$dst_dir"
+                _cp_die "profile '$dst' already exists"
+                return 1
+            end
+            cp -R "$src_dir" "$dst_dir"; or return 1
+            printf 'Cloned profile: %s -> %s\n' "$src" "$dst"
+            printf 'Config directory: %s\n' "$dst_dir"
+
+        case exec run
+            set -l name $rest[1]
+            if test -z "$name"
+                _cp_die "usage: claude-profile exec <name> [--] [claude args...]"
+                return 1
+            end
+            set -l dir (_cp_require_profile "$name"); or return 1
+            set -l fwd $rest[2..-1]
+            # Allow an optional -- separator before the claude args.
+            if test (count $fwd) -gt 0; and test "$fwd[1]" = "--"
+                set fwd $fwd[2..-1]
+            end
+            # `env` invokes the real binary (not this wrapper) with the profile
+            # set for this one command only — the session env is untouched.
+            env CLAUDE_CONFIG_DIR="$dir" claude $fwd
+
+        case show cat
+            set -l name $rest[1]
+            if test -z "$name"
+                if not test -f "$default_file"
+                    _cp_die "usage: claude-profile show <name> (no default profile set)"
+                    return 1
+                end
+                set name (cat "$default_file")
+            end
+            set -l dir (_cp_require_profile "$name"); or return 1
+            set -l settings "$dir/settings.json"
+            if not test -f "$settings"
+                _cp_die "profile '$name' has no settings.json. Create one with: claude-profile create --init $name"
+                return 1
+            end
+            cat "$settings"
+
+        case edit
+            set -l name $rest[1]
+            if test -z "$name"
+                if not test -f "$default_file"
+                    _cp_die "usage: claude-profile edit <name> (no default profile set)"
+                    return 1
+                end
+                set name (cat "$default_file")
+            end
+            set -l dir (_cp_require_profile "$name"); or return 1
+            set -l settings "$dir/settings.json"
+            if not test -f "$settings"
+                _cp_write_skeleton "$settings"
+                printf 'Created config skeleton: %s\n' "$settings"
+            end
+            if set -q VISUAL; and test -n "$VISUAL"
+                eval $VISUAL "$settings"
+            else if set -q EDITOR; and test -n "$EDITOR"
+                eval $EDITOR "$settings"
+            else
+                _cp_die "no \$VISUAL or \$EDITOR set; settings file is at: $settings"
+                return 1
+            end
+
+        case help -h --help
+            _cp_help
+
+        case ""
+            # Bare invocation: show status.
+            set -l active (_cp_active_name)
+            if test -n "$active"
+                printf 'Active profile: %s\n' "$active"
+                printf 'Config directory: %s\n' "$CLAUDE_CONFIG_DIR"
+            else if set -q CLAUDE_CONFIG_DIR; and test -n "$CLAUDE_CONFIG_DIR"
+                printf 'Active config directory: %s (not a managed profile)\n' "$CLAUDE_CONFIG_DIR"
+            else
+                printf 'No active profile\n'
+            end
+            set -l cur_default ""
+            if test -f "$default_file"
+                set cur_default (cat "$default_file")
+            end
+            if test -n "$cur_default"
+                printf 'Default profile: %s\n' "$cur_default"
+            else
+                printf 'No default profile set\n'
+            end
+
+        case '*'
+            _cp_die "unknown command '$cmd'. Run 'claude-profile help' for usage."
+            return 1
+    end
+end
+
+function _cp_write_skeleton --description 'Write a settings.json skeleton to the given path'
+    printf '%s\n' '{
+  "env": {
+    "ANTHROPIC_API_KEY": "YOUR_API_KEY_HERE",
+    "ANTHROPIC_BASE_URL": "https://YOUR_ENDPOINT_HERE",
+    "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "0"
+  },
+  "model": "claude-sonnet-4-6",
+  "advisorModel": "claude-opus-4-8",
+  "fallbackModel": ["claude-haiku-4-5"],
+  "effortLevel": "high",
+  "alwaysThinkingEnabled": false,
+  "permissions": {
+    "allow": [],
+    "deny": []
+  },
+  "autoMemoryEnabled": true,
+  "autoCompactEnabled": true,
+  "fileCheckpointingEnabled": true,
+  "cleanupPeriodDays": 30,
+  "language": "english",
+  "editorMode": "normal",
+  "preferredNotifChannel": "auto"
+}' >"$argv[1]"
+end
+
+function _cp_help --description 'Print claude-profile usage'
+    printf '%s\n' 'Usage: claude-profile [command] [args...]
+
+Commands:
+    (no command)            Show current profile status
+    use <name>              Switch session to the named profile
+    create [--init] <name>  Create a new profile (--init writes a settings.json skeleton)
+    list, ls                List all profiles
+    default [name]          Get or set the default profile
+    which [name]            Show the resolved config directory path
+    delete <name>           Delete a profile
+    rename <old> <new>      Rename a profile (follows default/active pointers)
+    clone <src> <dst>       Duplicate a profile, including its config
+    exec <name> [--] [args] Run claude with a profile once, without switching
+    show [name]             Print a profile'\''s settings.json (default profile if omitted)
+    edit [name]             Open a profile'\''s settings.json in $VISUAL/$EDITOR
+    help, -h, --help        Show this help message
+
+The claude command automatically uses the default profile. Use
+'\''claude-profile use <name>'\'' to override for the current session.
+
+Examples:
+    claude-profile create --init work
+    claude-profile default work
+    claude-profile use work
+    claude                          # runs with "work" profile
+    claude-profile exec personal -- --version
+    claude-profile clone work work-experiment'
+end
+
+# --- Completions ---
+
+function __cp_complete_profiles --description 'List profile names for completion'
+    set -l data (_cp_data_dir)
+    test -d "$data"; or return 0
+    for entry in "$data"/*/
+        test -d "$entry"; or continue
+        basename "$entry"
+    end
+end
+
+complete -c claude-profile -f
+complete -c claude-profile -n __fish_use_subcommand -a use -d 'Switch session to a profile'
+complete -c claude-profile -n __fish_use_subcommand -a create -d 'Create a new profile'
+complete -c claude-profile -n __fish_use_subcommand -a 'list ls' -d 'List all profiles'
+complete -c claude-profile -n __fish_use_subcommand -a default -d 'Get or set the default profile'
+complete -c claude-profile -n __fish_use_subcommand -a which -d 'Show a profile config directory'
+complete -c claude-profile -n __fish_use_subcommand -a 'delete rm' -d 'Delete a profile'
+complete -c claude-profile -n __fish_use_subcommand -a 'rename mv' -d 'Rename a profile'
+complete -c claude-profile -n __fish_use_subcommand -a 'clone copy cp' -d 'Duplicate a profile'
+complete -c claude-profile -n __fish_use_subcommand -a 'exec run' -d 'Run claude with a profile once'
+complete -c claude-profile -n __fish_use_subcommand -a 'show cat' -d 'Print a profile settings.json'
+complete -c claude-profile -n __fish_use_subcommand -a edit -d 'Edit a profile settings.json'
+complete -c claude-profile -n __fish_use_subcommand -a help -d 'Show help'
+complete -c claude-profile -n '__fish_seen_subcommand_from use default which delete rm rename mv clone copy cp exec run show cat edit' -a '(__cp_complete_profiles)'
+complete -c claude-profile -n '__fish_seen_subcommand_from create' -l init -d 'Write a settings.json skeleton'

--- a/claude-profile.sh
+++ b/claude-profile.sh
@@ -69,6 +69,48 @@ _cp_validate_name() {
     esac
 }
 
+# Writes a settings.json skeleton to the path given as $1.
+_cp_write_skeleton() {
+    cat > "$1" <<'SETTINGSEOF'
+{
+  "env": {
+    "ANTHROPIC_API_KEY": "YOUR_API_KEY_HERE",
+    "ANTHROPIC_BASE_URL": "https://YOUR_ENDPOINT_HERE",
+    "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "0"
+  },
+  "model": "claude-sonnet-4-6",
+  "advisorModel": "claude-opus-4-8",
+  "fallbackModel": ["claude-haiku-4-5"],
+  "effortLevel": "high",
+  "alwaysThinkingEnabled": false,
+  "permissions": {
+    "allow": [],
+    "deny": []
+  },
+  "autoMemoryEnabled": true,
+  "autoCompactEnabled": true,
+  "fileCheckpointingEnabled": true,
+  "cleanupPeriodDays": 30,
+  "language": "english",
+  "editorMode": "normal",
+  "preferredNotifChannel": "auto"
+}
+SETTINGSEOF
+}
+
+# Opens path $1 in $VISUAL or $EDITOR, if either is set. Returns 1 with a
+# diagnostic if neither is available.
+_cp_open_editor() {
+    if [ -n "${VISUAL:-}" ]; then
+        "${VISUAL}" "$1"
+    elif [ -n "${EDITOR:-}" ]; then
+        "${EDITOR}" "$1"
+    else
+        _cp_die "no \$VISUAL or \$EDITOR set; settings file is at: $1"
+        return 1
+    fi
+}
+
 # --- claude() wrapper ---
 # Auto-resolves the default profile before calling the real claude binary.
 # If CLAUDE_CONFIG_DIR is already set (e.g. via 'claude-profile use'),
@@ -173,37 +215,11 @@ claude-profile() {
             printf 'Config directory: %s\n' "$_cp_dir"
             if [ "$_cp_do_init" -eq 1 ]; then
                 _cp_settings="${_cp_dir}/settings.json"
-                cat > "$_cp_settings" <<'SETTINGSEOF'
-{
-  "env": {
-    "ANTHROPIC_API_KEY": "YOUR_API_KEY_HERE",
-    "ANTHROPIC_BASE_URL": "https://YOUR_ENDPOINT_HERE",
-    "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "0"
-  },
-  "model": "claude-sonnet-4-6",
-  "advisorModel": "claude-opus-4-8",
-  "fallbackModel": ["claude-haiku-4-5"],
-  "effortLevel": "high",
-  "alwaysThinkingEnabled": false,
-  "permissions": {
-    "allow": [],
-    "deny": []
-  },
-  "autoMemoryEnabled": true,
-  "autoCompactEnabled": true,
-  "fileCheckpointingEnabled": true,
-  "cleanupPeriodDays": 30,
-  "language": "english",
-  "editorMode": "normal",
-  "preferredNotifChannel": "auto"
-}
-SETTINGSEOF
+                _cp_write_skeleton "$_cp_settings"
                 printf 'Config skeleton written to: %s\n' "$_cp_settings"
                 printf 'Tip: remove "ANTHROPIC_BASE_URL" if using the default Anthropic endpoint.\n'
-                if [ -n "${VISUAL:-}" ]; then
-                    "${VISUAL}" "$_cp_settings"
-                elif [ -n "${EDITOR:-}" ]; then
-                    "${EDITOR}" "$_cp_settings"
+                if [ -n "${VISUAL:-}" ] || [ -n "${EDITOR:-}" ]; then
+                    _cp_open_editor "$_cp_settings"
                 fi
             fi
             ;;
@@ -352,6 +368,146 @@ SETTINGSEOF
             esac
             ;;
 
+        rename|mv)
+            shift
+            _cp_old="${1:-}"
+            _cp_new="${2:-}"
+            if [ -z "$_cp_old" ] || [ -z "$_cp_new" ]; then
+                _cp_die "usage: claude-profile rename <old> <new>"
+                return 1
+            fi
+            if [ -n "${3:-}" ]; then
+                _cp_die "unexpected argument: '$3'"
+                return 1
+            fi
+            _cp_validate_name "$_cp_old" || return 1
+            _cp_validate_name "$_cp_new" || return 1
+            _cp_old_dir="${_cp_data}/${_cp_old}"
+            _cp_new_dir="${_cp_data}/${_cp_new}"
+            if [ ! -d "$_cp_old_dir" ]; then
+                _cp_die "profile '${_cp_old}' does not exist"
+                return 1
+            fi
+            if [ -d "$_cp_new_dir" ]; then
+                _cp_die "profile '${_cp_new}' already exists"
+                return 1
+            fi
+            mv "$_cp_old_dir" "$_cp_new_dir" || return 1
+            printf 'Renamed profile: %s -> %s\n' "$_cp_old" "$_cp_new"
+            # Follow the rename through default and active pointers.
+            if [ -f "$_cp_default_file" ]; then
+                _cp_cur_default=$(cat "$_cp_default_file")
+                if [ "$_cp_cur_default" = "$_cp_old" ]; then
+                    printf '%s' "$_cp_new" > "$_cp_default_file"
+                    printf 'Updated default profile to: %s\n' "$_cp_new"
+                fi
+            fi
+            if [ "${CLAUDE_CONFIG_DIR:-}" = "$_cp_old_dir" ]; then
+                export CLAUDE_CONFIG_DIR="$_cp_new_dir"
+                printf 'Updated active profile to: %s\n' "$_cp_new"
+            fi
+            ;;
+
+        clone|copy|cp)
+            shift
+            _cp_src="${1:-}"
+            _cp_dst="${2:-}"
+            if [ -z "$_cp_src" ] || [ -z "$_cp_dst" ]; then
+                _cp_die "usage: claude-profile clone <source> <dest>"
+                return 1
+            fi
+            if [ -n "${3:-}" ]; then
+                _cp_die "unexpected argument: '$3'"
+                return 1
+            fi
+            _cp_validate_name "$_cp_src" || return 1
+            _cp_validate_name "$_cp_dst" || return 1
+            _cp_src_dir="${_cp_data}/${_cp_src}"
+            _cp_dst_dir="${_cp_data}/${_cp_dst}"
+            if [ ! -d "$_cp_src_dir" ]; then
+                _cp_die "profile '${_cp_src}' does not exist"
+                return 1
+            fi
+            if [ -d "$_cp_dst_dir" ]; then
+                _cp_die "profile '${_cp_dst}' already exists"
+                return 1
+            fi
+            cp -R "$_cp_src_dir" "$_cp_dst_dir" || return 1
+            printf 'Cloned profile: %s -> %s\n' "$_cp_src" "$_cp_dst"
+            printf 'Config directory: %s\n' "$_cp_dst_dir"
+            ;;
+
+        exec|run)
+            shift
+            _cp_name="${1:-}"
+            if [ -z "$_cp_name" ]; then
+                _cp_die "usage: claude-profile exec <name> [--] [claude args...]"
+                return 1
+            fi
+            shift
+            _cp_validate_name "$_cp_name" || return 1
+            _cp_dir="${_cp_data}/${_cp_name}"
+            if [ ! -d "$_cp_dir" ]; then
+                _cp_die "profile '${_cp_name}' does not exist. Create it with: claude-profile create ${_cp_name}"
+                return 1
+            fi
+            # Allow an optional -- separator before the forwarded claude args.
+            if [ "${1:-}" = "--" ]; then
+                shift
+            fi
+            # Run the real binary with the profile set for this one command only;
+            # the session environment is left untouched.
+            CLAUDE_CONFIG_DIR="$_cp_dir" command claude "$@"
+            ;;
+
+        show|cat)
+            shift
+            _cp_name="${1:-}"
+            if [ -z "$_cp_name" ]; then
+                if [ ! -f "$_cp_default_file" ]; then
+                    _cp_die "usage: claude-profile show <name> (no default profile set)"
+                    return 1
+                fi
+                _cp_name=$(cat "$_cp_default_file")
+            fi
+            _cp_validate_name "$_cp_name" || return 1
+            _cp_dir="${_cp_data}/${_cp_name}"
+            if [ ! -d "$_cp_dir" ]; then
+                _cp_die "profile '${_cp_name}' does not exist. Create it with: claude-profile create ${_cp_name}"
+                return 1
+            fi
+            _cp_settings="${_cp_dir}/settings.json"
+            if [ ! -f "$_cp_settings" ]; then
+                _cp_die "profile '${_cp_name}' has no settings.json. Create one with: claude-profile create --init ${_cp_name}"
+                return 1
+            fi
+            cat "$_cp_settings"
+            ;;
+
+        edit)
+            shift
+            _cp_name="${1:-}"
+            if [ -z "$_cp_name" ]; then
+                if [ ! -f "$_cp_default_file" ]; then
+                    _cp_die "usage: claude-profile edit <name> (no default profile set)"
+                    return 1
+                fi
+                _cp_name=$(cat "$_cp_default_file")
+            fi
+            _cp_validate_name "$_cp_name" || return 1
+            _cp_dir="${_cp_data}/${_cp_name}"
+            if [ ! -d "$_cp_dir" ]; then
+                _cp_die "profile '${_cp_name}' does not exist. Create it with: claude-profile create ${_cp_name}"
+                return 1
+            fi
+            _cp_settings="${_cp_dir}/settings.json"
+            if [ ! -f "$_cp_settings" ]; then
+                _cp_write_skeleton "$_cp_settings"
+                printf 'Created config skeleton: %s\n' "$_cp_settings"
+            fi
+            _cp_open_editor "$_cp_settings"
+            ;;
+
         help|-h|--help)
             cat <<'HELPEOF'
 Usage: claude-profile [command] [args...]
@@ -364,17 +520,23 @@ Commands:
     default [name]          Get or set the default profile
     which [name]            Show the resolved config directory path
     delete <name>           Delete a profile
+    rename <old> <new>      Rename a profile (follows default/active pointers)
+    clone <src> <dst>       Duplicate a profile, including its config
+    exec <name> [--] [args] Run claude with a profile once, without switching
+    show [name]             Print a profile's settings.json (default if omitted)
+    edit [name]             Open a profile's settings.json in $VISUAL/$EDITOR
     help, -h, --help        Show this help message
 
 The claude command automatically uses the default profile. Use
 'claude-profile use <name>' to override for the current session.
 
 Examples:
-    claude-profile create work
     claude-profile create --init work
     claude-profile default work
     claude-profile use work
     claude                          # runs with "work" profile
+    claude-profile exec personal -- --version
+    claude-profile clone work work-experiment
     claude-profile                  # shows active/default status
 HELPEOF
             ;;
@@ -414,3 +576,49 @@ HELPEOF
             ;;
     esac
 }
+
+# --- Completions (bash / zsh) ---
+# Registered only on interactive shells that provide programmable completion.
+# Lists subcommands at the first argument and profile names for subcommands
+# that take one. Fish completions live in claude-profile.fish.
+
+_cp_list_profiles() {
+    _cp_comp_data=$(_cp_data_dir)
+    [ -d "$_cp_comp_data" ] || return 0
+    for _cp_comp_entry in "$_cp_comp_data"/*/; do
+        [ -d "$_cp_comp_entry" ] || continue
+        basename "$_cp_comp_entry"
+    done
+}
+
+_cp_complete() {
+    # shellcheck disable=SC2034  # COMPREPLY is consumed by the completion system
+    _cp_cmds="use create list ls default which delete rename mv clone copy cp exec run show cat edit help"
+    if [ "${COMP_CWORD:-0}" -eq 1 ]; then
+        COMPREPLY=$(compgen -W "$_cp_cmds" -- "${COMP_WORDS[COMP_CWORD]}")
+        # shellcheck disable=SC2206
+        COMPREPLY=($COMPREPLY)
+        return 0
+    fi
+    case "${COMP_WORDS[1]}" in
+        use|default|which|delete|rename|mv|clone|copy|cp|exec|run|show|cat|edit)
+            # shellcheck disable=SC2207
+            COMPREPLY=($(compgen -W "$(_cp_list_profiles)" -- "${COMP_WORDS[COMP_CWORD]}"))
+            ;;
+        create)
+            # shellcheck disable=SC2207
+            COMPREPLY=($(compgen -W "--init" -- "${COMP_WORDS[COMP_CWORD]}"))
+            ;;
+        *)
+            COMPREPLY=()
+            ;;
+    esac
+}
+
+if [ -n "${BASH_VERSION:-}" ]; then
+    complete -F _cp_complete claude-profile 2>/dev/null
+elif [ -n "${ZSH_VERSION:-}" ]; then
+    # Enable bash-style completion in zsh, then register.
+    autoload -U +X bashcompinit 2>/dev/null && bashcompinit 2>/dev/null
+    complete -F _cp_complete claude-profile 2>/dev/null
+fi

--- a/install.sh
+++ b/install.sh
@@ -112,23 +112,51 @@ main() {
     chmod +r "${INSTALL_DIR}/claude-profile.sh"
     info "Installed: ${INSTALL_DIR}/claude-profile.sh"
 
+    # Also install the fish port. fish cannot source the POSIX script, so it
+    # ships as a separate native file sharing the same on-disk profile layout.
+    # Git Bash / MSYS2 do not provide fish, so skip it there.
+    if [ "$PLATFORM" != "gitbash" ]; then
+        step "Downloading claude-profile.fish..."
+        _tmp_fish="$(mktemp)"
+        trap 'rm -f "$_tmp_file" "$_tmp_fish"' EXIT
+        if download_file "${REPO_BASE}/claude-profile.fish" "$_tmp_fish"; then
+            cp "$_tmp_fish" "${INSTALL_DIR}/claude-profile.fish"
+            chmod +r "${INSTALL_DIR}/claude-profile.fish"
+            info "Installed: ${INSTALL_DIR}/claude-profile.fish"
+        else
+            warn "Could not download claude-profile.fish (skipping fish support)."
+        fi
+    fi
+
     # Detect shell profile and auto-append source line
     step "Configuring shell..."
     _shell_name=$(basename "${SHELL:-/bin/sh}")
+
+    # Single quotes are intentional: the expression must expand in the user's
+    # shell at login, not during installation. fish does not understand POSIX
+    # ${VAR:-default} expansion, so it gets a fish-syntax line instead.
+    # shellcheck disable=SC2016
+    _source_line='. "${XDG_DATA_HOME:-$HOME/.local/share}/claude-profile/claude-profile.sh"'
+    _source_marker='claude-profile.sh'
+
     case "$_shell_name" in
         zsh)  _profile_file="${ZDOTDIR:-$HOME}/.zshrc" ;;
         bash) _profile_file="${HOME}/.bashrc" ;;
+        fish)
+            _profile_file="${XDG_CONFIG_HOME:-$HOME/.config}/fish/config.fish"
+            # fish lacks POSIX ${VAR:-default} expansion, so embed the already
+            # resolved absolute install path rather than a portable expression.
+            _source_line="source \"${INSTALL_DIR}/claude-profile.fish\""
+            _source_marker='claude-profile.fish'
+            ;;
         *)    _profile_file="" ;;
     esac
 
-    # Single quotes are intentional: the expression must expand in the
-    # user's shell at login, not during installation.
-    # shellcheck disable=SC2016
-    _source_line='. "${XDG_DATA_HOME:-$HOME/.local/share}/claude-profile/claude-profile.sh"'
-
     if [ -n "$_profile_file" ]; then
+        # Create the config directory if needed (notably ~/.config/fish).
+        mkdir -p "$(dirname "$_profile_file")"
         # Idempotent: check if already present
-        if [ -f "$_profile_file" ] && grep -qF 'claude-profile.sh' "$_profile_file" 2>/dev/null; then
+        if [ -f "$_profile_file" ] && grep -qF "$_source_marker" "$_profile_file" 2>/dev/null; then
             info "Source line already in $_profile_file"
         else
             printf '\n# claude-profile: manage Claude Code configuration profiles\n%s\n' "$_source_line" >> "$_profile_file"


### PR DESCRIPTION
## Summary

Adds **fish shell support** plus several new profile management commands. fish is not POSIX-compatible and cannot source `claude-profile.sh`, so this introduces `claude-profile.fish` — a native fish port with the same commands and the **same on-disk profile layout**, so profiles created from bash/zsh are visible in fish and vice versa.

## What's included

- **`claude-profile.fish`** — native fish implementation (functions, `switch`, `string match`), with fish `complete` registrations for subcommands and profile names.
- **New commands** (in both the POSIX and fish implementations):
  - `rename <old> <new>` — rename a profile, following the default/active pointers
  - `clone <src> <dst>` — duplicate a profile, including its config dir
  - `exec <name> [--] [args]` — run `claude` with a profile for a single command, without switching the session
  - `show [name]` — print a profile's `settings.json` (default profile if omitted)
  - `edit [name]` — open `settings.json` in `$VISUAL`/`$EDITOR`
- **Completions** — tab-completion of subcommands and profile names for bash, zsh, and fish.
- **`install.sh`** — also installs `claude-profile.fish` and wires it into `config.fish` (skipped on Git Bash/MSYS2, which has no fish). The fish source line embeds the resolved absolute path because fish lacks POSIX `${VAR:-default}` expansion.
- **README** — documents the new commands, fish support, and manual fish install.

## Notes / design

- The POSIX `claude-profile.sh` changes are purely additive: the settings skeleton and editor-open logic were factored into `_cp_write_skeleton` / `_cp_open_editor` helpers (reused by `create --init` and the new `edit`), and the new subcommands were added ahead of the `help` case. No behavior change to existing commands.
- `exec` deliberately bypasses the `claude()` wrapper via a one-shot env assignment so the session environment is untouched.
- Windows (`.ps1`/`.cmd`) paths are unchanged.

## Testing

- `claude-profile.fish` exercised under fish: create/`--init`, list, default, use, which, show, clone, rename (incl. following the default pointer), name validation (`bad/name`, `a..b` rejected), and completions.
- `claude-profile.sh` exercised under bash: clone, rename-follows-default, show error path, completions.
- `sh -n install.sh` and `fish --no-execute claude-profile.fish` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)