### PR TITLE
feat: rate-limited diagnostic for local cache-write failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,17 @@ To disable the passive check entirely, set:
 export CLAUDE_PROFILE_NO_UPDATE_CHECK=1
 ```
 
+If the update-check cache itself can't be written (permissions, a full
+disk), you'll see a similar one-time-per-day warning instead:
+
+```
+claude-profile: warning: could not write update-check cache in ~/.local/share/claude-profile -- update notifications may not work until this is fixed
+```
+
+This doesn't block `claude` from running — it's just letting you know
+update notifications may be unreliable until the underlying issue is
+fixed.
+
 ## Platform Support
 
 | Script | Platform | Shell |

--- a/claude-profile-init.ps1
+++ b/claude-profile-init.ps1
@@ -95,8 +95,39 @@ function Write-CPUpdateCache {
     try {
         Set-Content -Path $tmpFile -Value "$Timestamp`n$Version`n$Notified" -ErrorAction Stop
         Move-Item -Path $tmpFile -Destination $cacheFile -Force -ErrorAction Stop
+        return $true
     } catch {
         Remove-Item -Path $tmpFile -Force -ErrorAction SilentlyContinue
+        return $false
+    }
+}
+
+# Rate-limited stderr diagnostic for persistent local cache-file I/O
+# failures (permissions, disk full) -- distinct from transient network
+# failures, which stay silent by design in Invoke-CPUpdateCheck.
+# Best-effort: uses a separate marker file so a broken .update-check
+# write doesn't also block this diagnostic; if even the marker can't be
+# written, this degrades to printing every invocation rather than
+# staying silent forever (never worse than the bug being fixed).
+#
+# Deliberately reuses $Script:CPUpdateInterval (default 86400s) as a
+# rolling window approximating "at most once per calendar day" -- not a
+# literal calendar-day boundary, and coupled to the same user-tunable
+# CLAUDE_PROFILE_UPDATE_CHECK_INTERVAL override that governs the update
+# check's own polling frequency. This is an accepted simplification, not
+# a separate config knob (matches the sh implementation's tradeoff).
+function Write-CPCacheFailureDiagnostic {
+    $installDir = Get-CPInstallDir
+    $marker = Join-Path $installDir '.update-check-diag'
+    $last = [long]0
+    if (Test-Path $marker) {
+        $raw = Get-Content $marker -Raw -ErrorAction SilentlyContinue
+        if ($raw -and ($raw.Trim() -match '^\d+$')) { $last = [long]$raw.Trim() }
+    }
+    $now = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+    if (($now - $last) -ge $Script:CPUpdateInterval) {
+        $host.UI.WriteErrorLine("claude-profile: warning: could not write update-check cache in $installDir -- update notifications may not work until this is fixed")
+        try { Set-Content -Path $marker -Value "$now" -ErrorAction Stop } catch { }
     }
 }
 
@@ -116,11 +147,11 @@ function Invoke-CPUpdateCheck {
                 # network/API failure: silently keep the previous cached version
             }
             if ($newVer -ne $cache.Version) {
-                Write-CPUpdateCache -Timestamp $now -Version $newVer -Notified 0
+                if (-not (Write-CPUpdateCache -Timestamp $now -Version $newVer -Notified 0)) { Write-CPCacheFailureDiagnostic }
                 $cache.Version = $newVer
                 $cache.Notified = 0
             } else {
-                Write-CPUpdateCache -Timestamp $now -Version $cache.Version -Notified $cache.Notified
+                if (-not (Write-CPUpdateCache -Timestamp $now -Version $cache.Version -Notified $cache.Notified)) { Write-CPCacheFailureDiagnostic }
             }
         }
 
@@ -129,7 +160,7 @@ function Invoke-CPUpdateCheck {
             if (Test-CPVersionLessThan -A $installed -B $cache.Version) {
                 $installedDisplay = if ($installed -eq 'unknown') { 'unknown' } else { "v$installed" }
                 $host.UI.WriteErrorLine("A new claude-profile version is available ($installedDisplay -> v$($cache.Version)). Run 'claude-profile update' to upgrade.")
-                Write-CPUpdateCache -Timestamp $now -Version $cache.Version -Notified 1
+                if (-not (Write-CPUpdateCache -Timestamp $now -Version $cache.Version -Notified 1)) { Write-CPCacheFailureDiagnostic }
             }
         }
     } catch {

--- a/claude-profile-init.ps1
+++ b/claude-profile-init.ps1
@@ -84,24 +84,6 @@ function Read-CPUpdateCache {
     return $result
 }
 
-# Atomic write: temp file + Move-Item, so a crash mid-write can't corrupt
-# the cache that every claude() invocation reads.
-function Write-CPUpdateCache {
-    param([long]$Timestamp, [string]$Version, [int]$Notified)
-    $installDir = Get-CPInstallDir
-    New-Item -ItemType Directory -Path $installDir -Force -ErrorAction SilentlyContinue | Out-Null
-    $cacheFile = Join-Path $installDir '.update-check'
-    $tmpFile = "$cacheFile.tmp.$PID"
-    try {
-        Set-Content -Path $tmpFile -Value "$Timestamp`n$Version`n$Notified" -ErrorAction Stop
-        Move-Item -Path $tmpFile -Destination $cacheFile -Force -ErrorAction Stop
-        return $true
-    } catch {
-        Remove-Item -Path $tmpFile -Force -ErrorAction SilentlyContinue
-        return $false
-    }
-}
-
 # Rate-limited stderr diagnostic for persistent local cache-file I/O
 # failures (permissions, disk full) -- distinct from transient network
 # failures, which stay silent by design in Invoke-CPUpdateCheck.
@@ -116,18 +98,48 @@ function Write-CPUpdateCache {
 # CLAUDE_PROFILE_UPDATE_CHECK_INTERVAL override that governs the update
 # check's own polling frequency. This is an accepted simplification, not
 # a separate config knob (matches the sh implementation's tradeoff).
+#
+# Called from inside Write-CPUpdateCache (not from its callers) so the
+# already-resolved install dir and timestamp are reused rather than
+# re-resolved -- this also means every current and future caller of
+# Write-CPUpdateCache gets this diagnostic for free, with no risk of a
+# call site forgetting to check the write's return value.
 function Write-CPCacheFailureDiagnostic {
-    $installDir = Get-CPInstallDir
-    $marker = Join-Path $installDir '.update-check-diag'
+    param([string]$InstallDir, [long]$Now)
+    $marker = Join-Path $InstallDir '.update-check-diag'
     $last = [long]0
     if (Test-Path $marker) {
         $raw = Get-Content $marker -Raw -ErrorAction SilentlyContinue
         if ($raw -and ($raw.Trim() -match '^\d+$')) { $last = [long]$raw.Trim() }
     }
-    $now = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
-    if (($now - $last) -ge $Script:CPUpdateInterval) {
-        $host.UI.WriteErrorLine("claude-profile: warning: could not write update-check cache in $installDir -- update notifications may not work until this is fixed")
-        try { Set-Content -Path $marker -Value "$now" -ErrorAction Stop } catch { }
+    if (($Now - $last) -ge $Script:CPUpdateInterval) {
+        $host.UI.WriteErrorLine("claude-profile: warning: could not write update-check cache in $InstallDir -- update notifications may not work until this is fixed")
+        $tmpMarker = "$marker.tmp.$PID"
+        try {
+            Set-Content -Path $tmpMarker -Value "$Now" -ErrorAction Stop
+            Move-Item -Path $tmpMarker -Destination $marker -Force -ErrorAction Stop
+        } catch {
+            Remove-Item -Path $tmpMarker -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+# Atomic write: temp file + Move-Item, so a crash mid-write can't corrupt
+# the cache that every claude() invocation reads.
+function Write-CPUpdateCache {
+    param([long]$Timestamp, [string]$Version, [int]$Notified)
+    $installDir = Get-CPInstallDir
+    New-Item -ItemType Directory -Path $installDir -Force -ErrorAction SilentlyContinue | Out-Null
+    $cacheFile = Join-Path $installDir '.update-check'
+    $tmpFile = "$cacheFile.tmp.$PID"
+    try {
+        Set-Content -Path $tmpFile -Value "$Timestamp`n$Version`n$Notified" -ErrorAction Stop
+        Move-Item -Path $tmpFile -Destination $cacheFile -Force -ErrorAction Stop
+        return $true
+    } catch {
+        Remove-Item -Path $tmpFile -Force -ErrorAction SilentlyContinue
+        Write-CPCacheFailureDiagnostic -InstallDir $installDir -Now $Timestamp
+        return $false
     }
 }
 
@@ -147,11 +159,11 @@ function Invoke-CPUpdateCheck {
                 # network/API failure: silently keep the previous cached version
             }
             if ($newVer -ne $cache.Version) {
-                if (-not (Write-CPUpdateCache -Timestamp $now -Version $newVer -Notified 0)) { Write-CPCacheFailureDiagnostic }
+                Write-CPUpdateCache -Timestamp $now -Version $newVer -Notified 0 | Out-Null
                 $cache.Version = $newVer
                 $cache.Notified = 0
             } else {
-                if (-not (Write-CPUpdateCache -Timestamp $now -Version $cache.Version -Notified $cache.Notified)) { Write-CPCacheFailureDiagnostic }
+                Write-CPUpdateCache -Timestamp $now -Version $cache.Version -Notified $cache.Notified | Out-Null
             }
         }
 
@@ -160,7 +172,7 @@ function Invoke-CPUpdateCheck {
             if (Test-CPVersionLessThan -A $installed -B $cache.Version) {
                 $installedDisplay = if ($installed -eq 'unknown') { 'unknown' } else { "v$installed" }
                 $host.UI.WriteErrorLine("A new claude-profile version is available ($installedDisplay -> v$($cache.Version)). Run 'claude-profile update' to upgrade.")
-                if (-not (Write-CPUpdateCache -Timestamp $now -Version $cache.Version -Notified 1)) { Write-CPCacheFailureDiagnostic }
+                Write-CPUpdateCache -Timestamp $now -Version $cache.Version -Notified 1 | Out-Null
             }
         }
     } catch {

--- a/claude-profile.cmd
+++ b/claude-profile.cmd
@@ -124,7 +124,9 @@ if !_vlt_a2! gtr !_vlt_b2! exit /b 1
 if !_vlt_a3! lss !_vlt_b3! exit /b 0
 exit /b 1
 
-:: write_update_cache <epoch> <version> <notified> — atomic via temp+rename
+:: write_update_cache <epoch> <version> <notified> — atomic via temp+rename.
+:: Signals success/failure via errorlevel (exit /b 0/1) so callers can
+:: detect persistent local cache I/O failures.
 :write_update_cache
 if not exist "%_CP_INSTALL_DIR%" mkdir "%_CP_INSTALL_DIR%" >nul 2>&1
 set "_wuc_tmp=%_CP_UPDATE_CACHE%.tmp.%RANDOM%"
@@ -133,8 +135,39 @@ set "_wuc_tmp=%_CP_UPDATE_CACHE%.tmp.%RANDOM%"
     echo %~2
     echo %~3
 )>"!_wuc_tmp!" 2>nul
-if exist "!_wuc_tmp!" (
-    move /y "!_wuc_tmp!" "%_CP_UPDATE_CACHE%" >nul 2>&1 || del /f /q "!_wuc_tmp!" >nul 2>&1
+if not exist "!_wuc_tmp!" exit /b 1
+move /y "!_wuc_tmp!" "%_CP_UPDATE_CACHE%" >nul 2>&1
+if errorlevel 1 (
+    del /f /q "!_wuc_tmp!" >nul 2>&1
+    exit /b 1
+)
+exit /b 0
+
+:: Rate-limited stderr diagnostic for persistent local cache-file I/O
+:: failures (permissions, disk full) -- distinct from transient network
+:: failures, which stay silent by design in :cp_update_check. Best-effort:
+:: uses a separate marker file so a broken .update-check write doesn't
+:: also block this diagnostic; if even the marker can't be written, this
+:: degrades to printing every invocation rather than staying silent
+:: forever (never worse than the bug being fixed).
+::
+:: Deliberately reuses _CP_UPDATE_INTERVAL (default 86400s) as a rolling
+:: window approximating "at most once per calendar day" -- not a literal
+:: calendar-day boundary, and coupled to the same user-tunable
+:: CLAUDE_PROFILE_UPDATE_CHECK_INTERVAL override that governs the update
+:: check's own polling frequency. This is an accepted simplification, not
+:: a separate config knob (matches the sh/ps1 implementations' tradeoff).
+:warn_cache_write_failure
+set "_wcf_marker=%_CP_INSTALL_DIR%\.update-check-diag"
+set "_wcf_last=0"
+if exist "!_wcf_marker!" set /p _wcf_last=<"!_wcf_marker!"
+echo !_wcf_last!| findstr /R "^[0-9][0-9]*$" >nul 2>&1
+if errorlevel 1 set "_wcf_last=0"
+call :get_epoch
+set /a _wcf_elapsed=_cp_epoch-_wcf_last
+if !_wcf_elapsed! geq !_CP_UPDATE_INTERVAL! (
+    echo claude-profile: warning: could not write update-check cache in %_CP_INSTALL_DIR% -- update notifications may not work until this is fixed >&2
+    2>nul >"!_wcf_marker!" echo !_cp_epoch!
 )
 goto :eof
 
@@ -174,10 +207,12 @@ if !_cpu_elapsed! geq !_CP_UPDATE_INTERVAL! (
     )
     if not "!_cpu_new_ver!"=="!_cpu_ver!" (
         call :write_update_cache "!_cp_epoch!" "!_cpu_new_ver!" "0"
+        if errorlevel 1 call :warn_cache_write_failure
         set "_cpu_ver=!_cpu_new_ver!"
         set "_cpu_notified=0"
     ) else (
         call :write_update_cache "!_cp_epoch!" "!_cpu_ver!" "!_cpu_notified!"
+        if errorlevel 1 call :warn_cache_write_failure
     )
 )
 
@@ -195,6 +230,7 @@ if "!_cpu_notified!"=="0" if not "!_cpu_ver!"=="unknown" (
         if "!_cpu_installed!"=="unknown" set "_cpu_installed_display=unknown"
         echo A new claude-profile version is available ^(!_cpu_installed_display! -^> v!_cpu_ver!^). Run 'claude-profile update' to upgrade. >&2
         call :write_update_cache "!_cp_epoch!" "!_cpu_ver!" "1"
+        if errorlevel 1 call :warn_cache_write_failure
     )
 )
 goto :eof

--- a/claude-profile.cmd
+++ b/claude-profile.cmd
@@ -134,7 +134,7 @@ set "_wuc_tmp=%_CP_UPDATE_CACHE%.tmp.%RANDOM%"
     echo %~1
     echo %~2
     echo %~3
-)>"!_wuc_tmp!" 2>nul
+) 2>nul >"!_wuc_tmp!"
 if not exist "!_wuc_tmp!" exit /b 1
 move /y "!_wuc_tmp!" "%_CP_UPDATE_CACHE%" >nul 2>&1
 if errorlevel 1 (
@@ -163,11 +163,14 @@ set "_wcf_last=0"
 if exist "!_wcf_marker!" set /p _wcf_last=<"!_wcf_marker!"
 echo !_wcf_last!| findstr /R "^[0-9][0-9]*$" >nul 2>&1
 if errorlevel 1 set "_wcf_last=0"
+set "_wcf_saved_epoch=!_cp_epoch!"
 call :get_epoch
-set /a _wcf_elapsed=_cp_epoch-_wcf_last
+set "_wcf_now=!_cp_epoch!"
+set "_cp_epoch=!_wcf_saved_epoch!"
+set /a _wcf_elapsed=_wcf_now-_wcf_last
 if !_wcf_elapsed! geq !_CP_UPDATE_INTERVAL! (
     echo claude-profile: warning: could not write update-check cache in %_CP_INSTALL_DIR% -- update notifications may not work until this is fixed >&2
-    2>nul >"!_wcf_marker!" echo !_cp_epoch!
+    2>nul >"!_wcf_marker!" echo !_wcf_now!
 )
 goto :eof
 

--- a/claude-profile.cmd
+++ b/claude-profile.cmd
@@ -124,25 +124,6 @@ if !_vlt_a2! gtr !_vlt_b2! exit /b 1
 if !_vlt_a3! lss !_vlt_b3! exit /b 0
 exit /b 1
 
-:: write_update_cache <epoch> <version> <notified> — atomic via temp+rename.
-:: Signals success/failure via errorlevel (exit /b 0/1) so callers can
-:: detect persistent local cache I/O failures.
-:write_update_cache
-if not exist "%_CP_INSTALL_DIR%" mkdir "%_CP_INSTALL_DIR%" >nul 2>&1
-set "_wuc_tmp=%_CP_UPDATE_CACHE%.tmp.%RANDOM%"
-(
-    echo %~1
-    echo %~2
-    echo %~3
-) 2>nul >"!_wuc_tmp!"
-if not exist "!_wuc_tmp!" exit /b 1
-move /y "!_wuc_tmp!" "%_CP_UPDATE_CACHE%" >nul 2>&1
-if errorlevel 1 (
-    del /f /q "!_wuc_tmp!" >nul 2>&1
-    exit /b 1
-)
-exit /b 0
-
 :: Rate-limited stderr diagnostic for persistent local cache-file I/O
 :: failures (permissions, disk full) -- distinct from transient network
 :: failures, which stay silent by design in :cp_update_check. Best-effort:
@@ -157,22 +138,71 @@ exit /b 0
 :: CLAUDE_PROFILE_UPDATE_CHECK_INTERVAL override that governs the update
 :: check's own polling frequency. This is an accepted simplification, not
 :: a separate config knob (matches the sh/ps1 implementations' tradeoff).
+::
+:: Called from inside :write_update_cache (not from its callers) so the
+:: epoch it already received as %~1 is reused directly instead of a
+:: second `call :get_epoch` (a second powershell.exe spawn) -- this also
+:: means every current and future caller of :write_update_cache gets this
+:: diagnostic for free, with no risk of a call site forgetting to check
+:: the errorlevel.
+:: Usage: call :warn_cache_write_failure <epoch>
 :warn_cache_write_failure
+set "_wcf_now=%~1"
 set "_wcf_marker=%_CP_INSTALL_DIR%\.update-check-diag"
 set "_wcf_last=0"
 if exist "!_wcf_marker!" set /p _wcf_last=<"!_wcf_marker!"
 echo !_wcf_last!| findstr /R "^[0-9][0-9]*$" >nul 2>&1
 if errorlevel 1 set "_wcf_last=0"
-set "_wcf_saved_epoch=!_cp_epoch!"
-call :get_epoch
-set "_wcf_now=!_cp_epoch!"
-set "_cp_epoch=!_wcf_saved_epoch!"
 set /a _wcf_elapsed=_wcf_now-_wcf_last
 if !_wcf_elapsed! geq !_CP_UPDATE_INTERVAL! (
     echo claude-profile: warning: could not write update-check cache in %_CP_INSTALL_DIR% -- update notifications may not work until this is fixed >&2
-    2>nul >"!_wcf_marker!" echo !_wcf_now!
+    set "_wcf_tmp=!_wcf_marker!.tmp.%RANDOM%"
+    2>nul >"!_wcf_tmp!" echo !_wcf_now!
+    if exist "!_wcf_tmp!" (
+        move /y "!_wcf_tmp!" "!_wcf_marker!" >nul 2>&1
+        if errorlevel 1 del /f /q "!_wcf_tmp!" >nul 2>&1
+    )
 )
 goto :eof
+
+:: write_update_cache <epoch> <version> <notified> — atomic via temp+rename.
+:: Signals success/failure via errorlevel (exit /b 0/1) so callers can
+:: detect persistent local cache I/O failures; on failure it also invokes
+:: the rate-limited diagnostic above itself, so callers don't need to.
+:write_update_cache
+if not exist "%_CP_INSTALL_DIR%" mkdir "%_CP_INSTALL_DIR%" >nul 2>&1
+set "_wuc_tmp=%_CP_UPDATE_CACHE%.tmp.%RANDOM%"
+(
+    echo %~1
+    echo %~2
+    echo %~3
+) 2>nul >"!_wuc_tmp!"
+if not exist "!_wuc_tmp!" (
+    call :warn_cache_write_failure "%~1"
+    exit /b 1
+)
+:: A disk-full failure mid-write can leave a truncated-but-existing temp
+:: file, which `if exist` alone can't detect. Read back the third line
+:: and confirm it matches what we tried to write, catching truncation
+:: before it gets moved into place as the real cache file.
+set "_wuc_verify="
+set "_wuc_line=0"
+for /f "usebackq delims=" %%L in ("!_wuc_tmp!") do (
+    set /a _wuc_line+=1
+    if "!_wuc_line!"=="3" set "_wuc_verify=%%L"
+)
+if not "!_wuc_verify!"=="%~3" (
+    del /f /q "!_wuc_tmp!" >nul 2>&1
+    call :warn_cache_write_failure "%~1"
+    exit /b 1
+)
+move /y "!_wuc_tmp!" "%_CP_UPDATE_CACHE%" >nul 2>&1
+if errorlevel 1 (
+    del /f /q "!_wuc_tmp!" >nul 2>&1
+    call :warn_cache_write_failure "%~1"
+    exit /b 1
+)
+exit /b 0
 
 :cp_update_check
 if defined CLAUDE_PROFILE_NO_UPDATE_CHECK goto :eof
@@ -210,12 +240,10 @@ if !_cpu_elapsed! geq !_CP_UPDATE_INTERVAL! (
     )
     if not "!_cpu_new_ver!"=="!_cpu_ver!" (
         call :write_update_cache "!_cp_epoch!" "!_cpu_new_ver!" "0"
-        if errorlevel 1 call :warn_cache_write_failure
         set "_cpu_ver=!_cpu_new_ver!"
         set "_cpu_notified=0"
     ) else (
         call :write_update_cache "!_cp_epoch!" "!_cpu_ver!" "!_cpu_notified!"
-        if errorlevel 1 call :warn_cache_write_failure
     )
 )
 
@@ -233,7 +261,6 @@ if "!_cpu_notified!"=="0" if not "!_cpu_ver!"=="unknown" (
         if "!_cpu_installed!"=="unknown" set "_cpu_installed_display=unknown"
         echo A new claude-profile version is available ^(!_cpu_installed_display! -^> v!_cpu_ver!^). Run 'claude-profile update' to upgrade. >&2
         call :write_update_cache "!_cp_epoch!" "!_cpu_ver!" "1"
-        if errorlevel 1 call :warn_cache_write_failure
     )
 )
 goto :eof

--- a/claude-profile.sh
+++ b/claude-profile.sh
@@ -331,7 +331,7 @@ _cp_warn_cache_write_failure() {
     case "$_cp_wcf_now" in ''|*[!0-9]*) return 0 ;; esac
     if [ $((_cp_wcf_now - _cp_wcf_last)) -ge "$_CP_UPDATE_INTERVAL" ]; then
         printf 'claude-profile: warning: could not write update-check cache in %s -- update notifications may not work until this is fixed\n' "$_cp_wcf_dir" >&2
-        printf '%s\n' "$_cp_wcf_now" > "$_cp_wcf_marker" 2>/dev/null
+        { printf '%s\n' "$_cp_wcf_now" > "$_cp_wcf_marker"; } 2>/dev/null
     fi
     return 0
 }

--- a/claude-profile.sh
+++ b/claude-profile.sh
@@ -312,13 +312,21 @@ _cp_write_update_cache() {
     return 0
 }
 
-# Rate-limited (at most once per _CP_UPDATE_INTERVAL) stderr diagnostic for
-# persistent local cache-file I/O failures (permissions, disk full) --
-# distinct from transient network failures, which stay silent by design
-# per _cp_update_check. Best-effort: uses a separate marker file so a
-# broken .update-check write doesn't also block this diagnostic; if even
-# the marker can't be written, this degrades to printing every invocation
-# rather than staying silent forever (never worse than the bug being fixed).
+# Rate-limited stderr diagnostic for persistent local cache-file I/O
+# failures (permissions, disk full) -- distinct from transient network
+# failures, which stay silent by design per _cp_update_check. Best-effort:
+# uses a separate marker file so a broken .update-check write doesn't also
+# block this diagnostic; if even the marker can't be written, this
+# degrades to printing every invocation rather than staying silent forever
+# (never worse than the bug being fixed).
+#
+# Deliberately reuses _CP_UPDATE_INTERVAL (default 86400s) as a rolling
+# window approximating the design's "at most once per calendar day" --
+# not a literal calendar-day boundary, and coupled to the same
+# user-tunable CLAUDE_PROFILE_UPDATE_CHECK_INTERVAL override that governs
+# the update check's own polling frequency. Lowering that interval (e.g.
+# for testing) also shortens this diagnostic's rate limit; this is an
+# accepted simplification, not a separate config knob.
 _cp_warn_cache_write_failure() {
     _cp_wcf_dir="$(_cp_install_dir)"
     _cp_wcf_marker="${_cp_wcf_dir}/.update-check-diag"

--- a/claude-profile.sh
+++ b/claude-profile.sh
@@ -312,6 +312,30 @@ _cp_write_update_cache() {
     return 0
 }
 
+# Rate-limited (at most once per _CP_UPDATE_INTERVAL) stderr diagnostic for
+# persistent local cache-file I/O failures (permissions, disk full) --
+# distinct from transient network failures, which stay silent by design
+# per _cp_update_check. Best-effort: uses a separate marker file so a
+# broken .update-check write doesn't also block this diagnostic; if even
+# the marker can't be written, this degrades to printing every invocation
+# rather than staying silent forever (never worse than the bug being fixed).
+_cp_warn_cache_write_failure() {
+    _cp_wcf_dir="$(_cp_install_dir)"
+    _cp_wcf_marker="${_cp_wcf_dir}/.update-check-diag"
+    _cp_wcf_last=0
+    if [ -f "$_cp_wcf_marker" ]; then
+        _cp_wcf_last=$(cat "$_cp_wcf_marker" 2>/dev/null)
+        case "$_cp_wcf_last" in ''|*[!0-9]*) _cp_wcf_last=0 ;; esac
+    fi
+    _cp_wcf_now=$(date +%s 2>/dev/null)
+    case "$_cp_wcf_now" in ''|*[!0-9]*) return 0 ;; esac
+    if [ $((_cp_wcf_now - _cp_wcf_last)) -ge "$_CP_UPDATE_INTERVAL" ]; then
+        printf 'claude-profile: warning: could not write update-check cache in %s -- update notifications may not work until this is fixed\n' "$_cp_wcf_dir" >&2
+        printf '%s\n' "$_cp_wcf_now" > "$_cp_wcf_marker" 2>/dev/null
+    fi
+    return 0
+}
+
 # Runs the passive update check, rate-limited to once per
 # CLAUDE_PROFILE_UPDATE_CHECK_INTERVAL seconds (default 24h). Prints a
 # one-line stderr notice the first time a newer version is seen. Every
@@ -334,11 +358,11 @@ _cp_update_check() {
             [ -n "$_cp_extracted" ] && _cp_new_ver="$_cp_extracted"
         fi
         if [ "$_cp_new_ver" != "$_cp_cache_ver" ]; then
-            _cp_write_update_cache "$_cp_now" "$_cp_new_ver" 0
+            _cp_write_update_cache "$_cp_now" "$_cp_new_ver" 0 || _cp_warn_cache_write_failure
             _cp_cache_ver="$_cp_new_ver"
             _cp_cache_notified=0
         else
-            _cp_write_update_cache "$_cp_now" "$_cp_cache_ver" "$_cp_cache_notified"
+            _cp_write_update_cache "$_cp_now" "$_cp_cache_ver" "$_cp_cache_notified" || _cp_warn_cache_write_failure
         fi
     fi
 
@@ -351,7 +375,7 @@ _cp_update_check() {
             esac
             printf "A new claude-profile version is available (%s -> v%s). Run 'claude-profile update' to upgrade.\\n" \
                 "$_cp_installed_display" "$_cp_cache_ver" >&2
-            _cp_write_update_cache "$_cp_now" "$_cp_cache_ver" 1
+            _cp_write_update_cache "$_cp_now" "$_cp_cache_ver" 1 || _cp_warn_cache_write_failure
         fi
     fi
     return 0

--- a/claude-profile.sh
+++ b/claude-profile.sh
@@ -297,18 +297,12 @@ _cp_read_update_cache() {
     return 0
 }
 
-# Writes the cache atomically (temp file + rename), so concurrent
-# invocations can't torn-write it. Usage: _cp_write_update_cache TS VER NOTIFIED
-_cp_write_update_cache() {
-    _cp_wuc_dir="$(_cp_install_dir)"
-    mkdir -p "$_cp_wuc_dir" 2>/dev/null || return 1
-    _cp_wuc_file="${_cp_wuc_dir}/.update-check"
-    _cp_wuc_tmp="${_cp_wuc_file}.tmp.$$"
-    if ! printf '%s\n%s\n%s\n' "$1" "$2" "$3" > "$_cp_wuc_tmp" 2>/dev/null; then
-        rm -f "$_cp_wuc_tmp" 2>/dev/null
-        return 1
-    fi
-    mv -f "$_cp_wuc_tmp" "$_cp_wuc_file" 2>/dev/null || { rm -f "$_cp_wuc_tmp" 2>/dev/null; return 1; }
+# Writes a single value to a file atomically (temp file + rename).
+# Usage: _cp_atomic_write FILE VALUE
+_cp_atomic_write() {
+    _cp_aw_tmp="${1}.tmp.$$"
+    { printf '%s\n' "$2" > "$_cp_aw_tmp"; } 2>/dev/null || { rm -f "$_cp_aw_tmp" 2>/dev/null; return 1; }
+    mv -f "$_cp_aw_tmp" "$1" 2>/dev/null || { rm -f "$_cp_aw_tmp" 2>/dev/null; return 1; }
     return 0
 }
 
@@ -327,20 +321,46 @@ _cp_write_update_cache() {
 # the update check's own polling frequency. Lowering that interval (e.g.
 # for testing) also shortens this diagnostic's rate limit; this is an
 # accepted simplification, not a separate config knob.
+#
+# Called from inside _cp_write_update_cache (not from its callers) so the
+# already-resolved install dir and epoch are reused rather than
+# re-resolved — this also means every current and future caller of
+# _cp_write_update_cache gets this diagnostic for free, with no risk of a
+# call site forgetting to check the write's return value.
+# Usage: _cp_warn_cache_write_failure DIR EPOCH
 _cp_warn_cache_write_failure() {
-    _cp_wcf_dir="$(_cp_install_dir)"
+    _cp_wcf_dir="$1"
+    _cp_wcf_now="$2"
     _cp_wcf_marker="${_cp_wcf_dir}/.update-check-diag"
     _cp_wcf_last=0
     if [ -f "$_cp_wcf_marker" ]; then
-        _cp_wcf_last=$(cat "$_cp_wcf_marker" 2>/dev/null)
-        case "$_cp_wcf_last" in ''|*[!0-9]*) _cp_wcf_last=0 ;; esac
+        _cp_wcf_read=$(cat "$_cp_wcf_marker" 2>/dev/null)
+        case "$_cp_wcf_read" in ''|*[!0-9]*) ;; *) _cp_wcf_last="$_cp_wcf_read" ;; esac
     fi
-    _cp_wcf_now=$(date +%s 2>/dev/null)
-    case "$_cp_wcf_now" in ''|*[!0-9]*) return 0 ;; esac
     if [ $((_cp_wcf_now - _cp_wcf_last)) -ge "$_CP_UPDATE_INTERVAL" ]; then
         printf 'claude-profile: warning: could not write update-check cache in %s -- update notifications may not work until this is fixed\n' "$_cp_wcf_dir" >&2
-        { printf '%s\n' "$_cp_wcf_now" > "$_cp_wcf_marker"; } 2>/dev/null
+        _cp_atomic_write "$_cp_wcf_marker" "$_cp_wcf_now"
     fi
+    return 0
+}
+
+# Writes the cache atomically (temp file + rename), so concurrent
+# invocations can't torn-write it. Usage: _cp_write_update_cache TS VER NOTIFIED
+_cp_write_update_cache() {
+    _cp_wuc_dir="$(_cp_install_dir)"
+    mkdir -p "$_cp_wuc_dir" 2>/dev/null || { _cp_warn_cache_write_failure "$_cp_wuc_dir" "$1"; return 1; }
+    _cp_wuc_file="${_cp_wuc_dir}/.update-check"
+    _cp_wuc_tmp="${_cp_wuc_file}.tmp.$$"
+    if ! printf '%s\n%s\n%s\n' "$1" "$2" "$3" > "$_cp_wuc_tmp" 2>/dev/null; then
+        rm -f "$_cp_wuc_tmp" 2>/dev/null
+        _cp_warn_cache_write_failure "$_cp_wuc_dir" "$1"
+        return 1
+    fi
+    mv -f "$_cp_wuc_tmp" "$_cp_wuc_file" 2>/dev/null || {
+        rm -f "$_cp_wuc_tmp" 2>/dev/null
+        _cp_warn_cache_write_failure "$_cp_wuc_dir" "$1"
+        return 1
+    }
     return 0
 }
 
@@ -366,11 +386,11 @@ _cp_update_check() {
             [ -n "$_cp_extracted" ] && _cp_new_ver="$_cp_extracted"
         fi
         if [ "$_cp_new_ver" != "$_cp_cache_ver" ]; then
-            _cp_write_update_cache "$_cp_now" "$_cp_new_ver" 0 || _cp_warn_cache_write_failure
+            _cp_write_update_cache "$_cp_now" "$_cp_new_ver" 0
             _cp_cache_ver="$_cp_new_ver"
             _cp_cache_notified=0
         else
-            _cp_write_update_cache "$_cp_now" "$_cp_cache_ver" "$_cp_cache_notified" || _cp_warn_cache_write_failure
+            _cp_write_update_cache "$_cp_now" "$_cp_cache_ver" "$_cp_cache_notified"
         fi
     fi
 
@@ -383,7 +403,7 @@ _cp_update_check() {
             esac
             printf "A new claude-profile version is available (%s -> v%s). Run 'claude-profile update' to upgrade.\\n" \
                 "$_cp_installed_display" "$_cp_cache_ver" >&2
-            _cp_write_update_cache "$_cp_now" "$_cp_cache_ver" 1 || _cp_warn_cache_write_failure
+            _cp_write_update_cache "$_cp_now" "$_cp_cache_ver" 1
         fi
     fi
     return 0


### PR DESCRIPTION
## Summary
- Implements the design doc's requirement (docs/plans/2026-07-06-auto-updater-design.md §2/§5) for a rate-limited stderr diagnostic when the local `.update-check` cache file itself can't be read/written — distinct from silent network failures, which stay silent by design.
- Adds this to all three implementations: `claude-profile.sh`, `claude-profile-init.ps1`, `claude-profile.cmd`.
- This was flagged by a final cross-implementation review of PR #12 as a real gap between the approved design and what shipped (the GPG-signing descope in that same PR was intentional/documented; this one wasn't).

Each implementation uses a separate `.update-check-diag` marker file (since the main cache file may itself be what's unwritable), rate-limited via the existing `_CP_UPDATE_INTERVAL`/`$Script:CPUpdateInterval` window, and degrades to printing every invocation (rather than crashing or going silent forever) if even the marker can't be persisted.

## Test plan
- [x] sh: verified live (happy path, write-failure rate-limiting, marker-also-fails degraded case); `shellcheck`/`checkbashisms` clean
- [x] ps1: verified live via Docker+pwsh (non-root, permissions enforced); AST parses cleanly
- [x] cmd: verified live via Wine `cmd.exe`; caught and fixed two real batch-specific bugs during review (a redirect-ordering leak, and cross-call variable clobbering since batch has no subroutine scoping)
- [x] Each implementation went through independent spec-compliance and code-quality review passes, with fix-and-reverify cycles for every issue found

🤖 Generated with [Claude Code](https://claude.com/claude-code)