### PR TITLE
feat: auto-switch profiles from a .claude-profile dotfile on cd

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,9 +31,21 @@ All three implementations share the same command interface:
 | `claude-profile create <name>` | Create a new profile |
 | `claude-profile list` | List all profiles (marks default and active) |
 | `claude-profile default [name]` | Get or set the default profile |
+| `claude-profile local [name]` | Show, set, or `--remove` the directory-local `.claude-profile` |
+| `claude-profile auto [on\|off\|status]` | Control directory-local auto-switching (sh/ps1 only) |
 | `claude-profile which [name]` | Show the resolved config directory path |
 | `claude-profile delete <name>` | Delete a profile (with confirmation) |
 | `claude-profile help` | Show help |
+
+## Directory-Local Profiles
+
+A `.claude-profile` file (first non-empty, non-comment line = profile name) switches `CLAUDE_CONFIG_DIR` when the shell enters that directory or any descendant, and reverts on leaving. An explicit `claude-profile use` pins the session and wins until `claude-profile auto on`.
+
+The pin is tracked via an exported `CLAUDE_PROFILE_AUTO_SET` marker: auto-switching only manages `CLAUDE_CONFIG_DIR` when its value equals that marker, so anything set by hand (or inherited from outside) is left alone. Exporting it means nested shells keep auto-managing rather than treating the inherited value as manual.
+
+Directory-change hooks differ per shell: zsh `chpwd`, bash `PROMPT_COMMAND`, `cd` wrapper elsewhere; PowerShell 6+ `LocationChangedAction`, PowerShell 5.1 `prompt` wrapper. cmd.exe has no hook — a bare `call claude-profile.cmd` resolves the dotfile at invocation time instead.
+
+Because bash re-runs the resolver on every prompt, `_cp_auto_switch` short-circuits when `$PWD` is unchanged and the upward walk uses only parameter expansion (no `dirname` fork per component). That short-circuit also rate-limits the "invalid/missing profile" warnings to once per directory entry.
 
 ## Validation Rules
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ claude -p "explain this code"
 | `claude-profile create <name>` | Create a new profile |
 | `claude-profile list` | List all profiles |
 | `claude-profile default [name]` | Get or set the default profile |
+| `claude-profile local [name]` | Show, set, or `--remove` this directory's `.claude-profile` |
+| `claude-profile auto [on\|off\|status]` | Control directory-local auto-switching (not on cmd.exe) |
 | `claude-profile delete <name>` | Delete a profile (with confirmation) |
 | `claude-profile which [name]` | Show the config directory path |
 | `claude-profile version` | Show the installed version |
@@ -55,9 +57,10 @@ claude -p "explain this code"
 
 Claude Code supports a `CLAUDE_CONFIG_DIR` environment variable that redirects where it stores configuration and data. `claude-profile` provides a `claude()` shell function that wraps the real `claude` binary:
 
-1. Before each invocation, the wrapper checks if a default profile exists and auto-sets `CLAUDE_CONFIG_DIR`.
-2. If `CLAUDE_CONFIG_DIR` is already set (e.g., via `claude-profile use`), it is used as-is.
-3. The real `claude` binary is then called with all your arguments.
+1. On each directory change, the nearest `.claude-profile` file (if any) sets `CLAUDE_CONFIG_DIR` — see [Per-Directory Profiles](#per-directory-profiles).
+2. Before each invocation, the wrapper checks if a default profile exists and auto-sets `CLAUDE_CONFIG_DIR`.
+3. If `CLAUDE_CONFIG_DIR` is already set (e.g., via `claude-profile use`), it is used as-is.
+4. The real `claude` binary is then called with all your arguments.
 
 This means you never need to think about profiles during normal use -- just run `claude` as you always have.
 
@@ -72,6 +75,65 @@ claude                          # uses "personal" for this shell session
 ```
 
 The override lasts until you close the shell or run `claude-profile use` again.
+
+### Per-Directory Profiles
+
+A directory can pin itself (and everything under it) to a profile by holding
+a `.claude-profile` file whose first non-empty, non-comment line is a profile
+name:
+
+```sh
+cd ~/work/acme
+claude-profile local work        # writes ./.claude-profile containing "work"
+```
+
+Your shell now switches to `work` whenever you `cd` into that tree, and back
+to the default when you leave:
+
+```
+$ cd ~/work/acme/api
+claude-profile: profile 'work' (from /home/you/work/acme/.claude-profile)
+$ cd ~
+claude-profile: directory profile cleared; using the default profile
+```
+
+The file is plain text — you can commit it to a repo, and blank lines and
+`#` comments are ignored:
+
+```
+# every checkout of this repo uses the client's isolated profile
+client-acme
+```
+
+Precedence and control:
+
+- An explicit `claude-profile use <name>` **pins** the session: it wins over
+  any `.claude-profile` until you run `claude-profile auto on`, which clears
+  the pin and re-resolves the current directory.
+- `claude-profile auto off` disables auto-switching for the session;
+  `claude-profile auto status` shows what's in effect.
+- `CLAUDE_PROFILE_NO_AUTO_SWITCH=1` disables it entirely,
+  `CLAUDE_PROFILE_AUTO_QUIET=1` switches silently.
+- A `.claude-profile` naming a profile that doesn't exist (or an invalid
+  name) is reported on stderr once per directory entry and otherwise ignored.
+- `claude-profile local --remove` deletes the `.claude-profile` in the
+  current directory.
+
+Hooking into directory changes is per-shell: zsh uses `chpwd`, bash uses
+`PROMPT_COMMAND`, and other POSIX shells get a `cd` wrapper. PowerShell 6+
+uses `LocationChangedAction`; Windows PowerShell 5.1 hooks the `prompt`
+function.
+
+**cmd.exe is different.** It has no `cd` hook and no transparent `claude`
+wrapper, so it can't switch automatically. Instead, a bare
+`call claude-profile.cmd` prefers the nearest `.claude-profile` over the
+default profile, and `claude-profile local <name>` writes the file:
+
+```bat
+claude-profile local work
+call claude-profile
+claude
+```
 
 ### Profile Storage
 

--- a/claude-profile-init.ps1
+++ b/claude-profile-init.ps1
@@ -19,6 +19,16 @@ function Get-CPInstallDir {
     return Join-Path $HOME '.local' 'share' 'claude-profile'
 }
 
+function Get-CPDataDir {
+    if ($IsWindows -or ($PSVersionTable.PSEdition -eq 'Desktop')) {
+        return Join-Path $env:LOCALAPPDATA 'claude-profiles'
+    }
+    if ($env:XDG_DATA_HOME) {
+        return Join-Path $env:XDG_DATA_HOME 'claude-profiles'
+    }
+    return Join-Path $HOME '.local' 'share' 'claude-profiles'
+}
+
 function Get-CPInstalledVersion {
     $versionFile = Join-Path (Get-CPInstallDir) 'VERSION'
     if (Test-Path $versionFile) {
@@ -180,6 +190,157 @@ function Invoke-CPUpdateCheck {
     }
 }
 
+# --- Directory-local profile (.claude-profile) auto-switching ---
+#
+# A directory may contain a `.claude-profile` file whose first non-empty,
+# non-comment line names a profile. Entering that directory (or any
+# descendant) switches CLAUDE_CONFIG_DIR to it; leaving reverts to the
+# default. An explicit `claude-profile use <name>` pins the session and
+# suppresses auto-switching until `claude-profile auto on`.
+#
+# Environment knobs:
+#   CLAUDE_PROFILE_NO_AUTO_SWITCH=1   disable auto-switching entirely
+#   CLAUDE_PROFILE_AUTO_QUIET=1       switch silently (no stderr notices)
+#
+# CLAUDE_PROFILE_AUTO_SET is an environment variable (not a script variable)
+# so nested shells know the current CLAUDE_CONFIG_DIR came from
+# auto-switching rather than from an explicit `use`.
+
+$Script:CPDotfileName = '.claude-profile'
+
+function Write-CPAutoNotice {
+    param([string]$Message)
+    if ($env:CLAUDE_PROFILE_AUTO_QUIET) { return }
+    $host.UI.WriteErrorLine("claude-profile: $Message")
+}
+
+# Returns the path of the nearest .claude-profile at or above $StartDir, or
+# $null when none exists.
+function Find-CPDotfile {
+    param([string]$StartDir)
+    if (-not $StartDir) { return $null }
+    try {
+        $dir = Get-Item -LiteralPath $StartDir -Force -ErrorAction Stop
+    } catch {
+        return $null
+    }
+    while ($dir) {
+        $candidate = Join-Path $dir.FullName $Script:CPDotfileName
+        if (Test-Path -LiteralPath $candidate -PathType Leaf) { return $candidate }
+        $dir = $dir.Parent
+    }
+    return $null
+}
+
+# Returns the first non-empty, non-comment line of $Path, trimmed, or $null.
+function Read-CPDotfile {
+    param([string]$Path)
+    try {
+        $lines = @(Get-Content -LiteralPath $Path -ErrorAction Stop)
+    } catch {
+        return $null
+    }
+    foreach ($line in $lines) {
+        $trimmed = $line.Trim()
+        if (-not $trimmed) { continue }
+        if ($trimmed.StartsWith('#')) { continue }
+        return $trimmed
+    }
+    return $null
+}
+
+# Returns the current filesystem directory, or $null when the session is on a
+# non-filesystem provider (Registry:, Cert:, ...) where .claude-profile has no
+# meaning.
+function Get-CPCurrentFileSystemPath {
+    $loc = Get-Location
+    if ($loc.Provider.Name -ne 'FileSystem') { return $null }
+    return $loc.ProviderPath
+}
+
+# Resolves and applies the directory-local profile for the current directory.
+# Safe to call repeatedly: it short-circuits when the directory hasn't
+# changed, which also rate-limits the warnings below to once per directory
+# entry rather than once per prompt.
+function Invoke-CPAutoSwitch {
+    try {
+        if ($env:CLAUDE_PROFILE_NO_AUTO_SWITCH) { return }
+        if ($Script:CPAutoOff) { return }
+        $cwd = Get-CPCurrentFileSystemPath
+        if (-not $cwd) { return }
+        if ($cwd -eq $Script:CPAutoLastPwd) { return }
+        $Script:CPAutoLastPwd = $cwd
+
+        # An explicitly-chosen profile (claude-profile use, or a
+        # CLAUDE_CONFIG_DIR inherited from outside) wins over .claude-profile.
+        if ($env:CLAUDE_CONFIG_DIR -and ($env:CLAUDE_CONFIG_DIR -ne $env:CLAUDE_PROFILE_AUTO_SET)) { return }
+
+        $dotfile = Find-CPDotfile -StartDir $cwd
+        $name = if ($dotfile) { Read-CPDotfile -Path $dotfile } else { $null }
+
+        if (-not $name) {
+            if ($env:CLAUDE_PROFILE_AUTO_SET) {
+                Remove-Item Env:\CLAUDE_CONFIG_DIR -ErrorAction SilentlyContinue
+                Remove-Item Env:\CLAUDE_PROFILE_AUTO_SET -ErrorAction SilentlyContinue
+                Write-CPAutoNotice 'directory profile cleared; using the default profile'
+            }
+            if ($dotfile) {
+                $host.UI.WriteErrorLine("claude-profile: ignoring ${dotfile}: no profile name in file")
+            }
+            return
+        }
+
+        if ($name -notmatch '^[A-Za-z0-9_-]+$') {
+            $host.UI.WriteErrorLine("claude-profile: ignoring ${dotfile}: invalid profile name '$name'")
+            return
+        }
+
+        $profileDir = Join-Path (Get-CPDataDir) $name
+        if (-not (Test-Path -LiteralPath $profileDir -PathType Container)) {
+            $host.UI.WriteErrorLine("claude-profile: ignoring ${dotfile}: profile '$name' does not exist")
+            return
+        }
+
+        if ($env:CLAUDE_CONFIG_DIR -ne $profileDir) {
+            $env:CLAUDE_CONFIG_DIR = $profileDir
+            Write-CPAutoNotice "profile '$name' (from $dotfile)"
+        }
+        $env:CLAUDE_PROFILE_AUTO_SET = $profileDir
+    } catch {
+        # Never let auto-switching break the prompt.
+    }
+}
+
+# Registers Invoke-CPAutoSwitch with whatever directory-change mechanism the
+# running host offers. PowerShell 6+ has a real LocationChangedAction hook;
+# Windows PowerShell 5.1 only has the prompt function. Both paths are guarded
+# so re-dot-sourcing this file can't chain a handler into itself.
+if (-not $Script:CPLocationHookInstalled) {
+    if ($ExecutionContext.InvokeCommand.PSObject.Properties.Name -contains 'LocationChangedAction') {
+        $Script:CPPrevLocationAction = $ExecutionContext.InvokeCommand.LocationChangedAction
+        $ExecutionContext.InvokeCommand.LocationChangedAction = {
+            param($EventSender, $EventArgs)
+            if ($Script:CPPrevLocationAction) { & $Script:CPPrevLocationAction $EventSender $EventArgs }
+            Invoke-CPAutoSwitch
+        }
+    } else {
+        $Script:CPPrevPrompt = $function:prompt
+        function global:prompt {
+            Invoke-CPAutoSwitch
+            if ($Script:CPPrevPrompt) {
+                & $Script:CPPrevPrompt
+            } else {
+                "PS $($ExecutionContext.SessionState.Path.CurrentLocation)$('>' * ($NestedPromptLevel + 1)) "
+            }
+        }
+    }
+    $Script:CPLocationHookInstalled = $true
+}
+
+# Resolve once at load time so a session started inside a .claude-profile
+# tree is already on the right profile.
+Invoke-CPAutoSwitch
+
 # --- claude wrapper ---
 # Auto-resolves the default profile before calling the real claude binary.
 # If CLAUDE_CONFIG_DIR is already set (e.g. via 'claude-profile use'),
@@ -187,22 +348,21 @@ function Invoke-CPUpdateCheck {
 
 function claude {
     Invoke-CPUpdateCheck
+    # Covers directory changes the hook above may have missed.
+    Invoke-CPAutoSwitch
     if (-not $env:CLAUDE_CONFIG_DIR) {
-        if ($IsWindows -or ($PSVersionTable.PSEdition -eq 'Desktop')) {
-            $DataDir = Join-Path $env:LOCALAPPDATA 'claude-profiles'
-        } else {
-            if ($env:XDG_DATA_HOME) {
-                $DataDir = Join-Path $env:XDG_DATA_HOME 'claude-profiles'
-            } else {
-                $DataDir = Join-Path $HOME '.local' 'share' 'claude-profiles'
-            }
-        }
+        $DataDir = Get-CPDataDir
         $DefaultFile = Join-Path $DataDir '.default'
         if (Test-Path $DefaultFile) {
             $Name = (Get-Content $DefaultFile -Raw).Trim()
             $ProfilePath = Join-Path $DataDir $Name
             if ($Name -and (Test-Path $ProfilePath -PathType Container)) {
                 $env:CLAUDE_CONFIG_DIR = $ProfilePath
+                # Mark it auto-managed, not an explicit pin: without this, the
+                # first `claude` run would freeze the session on the default
+                # profile and later .claude-profile directories would be
+                # ignored.
+                $env:CLAUDE_PROFILE_AUTO_SET = $ProfilePath
             }
         }
     }
@@ -221,15 +381,7 @@ function claude-profile {
     $ErrorActionPreference = 'Stop'
 
     # --- Platform-aware data directory ---
-    if ($IsWindows -or ($PSVersionTable.PSEdition -eq 'Desktop')) {
-        $DataDir = Join-Path $env:LOCALAPPDATA 'claude-profiles'
-    } else {
-        if ($env:XDG_DATA_HOME) {
-            $DataDir = Join-Path $env:XDG_DATA_HOME 'claude-profiles'
-        } else {
-            $DataDir = Join-Path $HOME '.local' 'share' 'claude-profiles'
-        }
-    }
+    $DataDir = Get-CPDataDir
     $DefaultFile = Join-Path $DataDir '.default'
 
     # --- Parse $args manually ---
@@ -291,7 +443,105 @@ function claude-profile {
                 return
             }
             $env:CLAUDE_CONFIG_DIR = $ProfileDir
+            # Dropping the auto-set marker pins the session: subsequent
+            # directory changes will no longer override this choice.
+            Remove-Item Env:\CLAUDE_PROFILE_AUTO_SET -ErrorAction SilentlyContinue
             Write-Host "Switched to profile: $ArgName"
+        }
+
+        'auto' {
+            # Defaulted to 'status' rather than $null so the inner switch has a
+            # real value to match on.
+            $Sub = if ($args.Count -gt 1) { $args[1] } else { 'status' }
+            switch ($Sub) {
+                'on' {
+                    $Script:CPAutoOff = $false
+                    Remove-Item Env:\CLAUDE_CONFIG_DIR -ErrorAction SilentlyContinue
+                    Remove-Item Env:\CLAUDE_PROFILE_AUTO_SET -ErrorAction SilentlyContinue
+                    $Script:CPAutoLastPwd = $null
+                    Invoke-CPAutoSwitch
+                    Write-Host 'Directory-local auto-switching enabled.'
+                }
+                'off' {
+                    $Script:CPAutoOff = $true
+                    Write-Host 'Directory-local auto-switching disabled for this session.'
+                }
+                'status' {
+                    if ($env:CLAUDE_PROFILE_NO_AUTO_SWITCH) {
+                        Write-Host 'Auto-switching: disabled (CLAUDE_PROFILE_NO_AUTO_SWITCH is set)'
+                    } elseif ($Script:CPAutoOff) {
+                        Write-Host 'Auto-switching: disabled for this session'
+                    } elseif ($env:CLAUDE_CONFIG_DIR -and ($env:CLAUDE_CONFIG_DIR -ne $env:CLAUDE_PROFILE_AUTO_SET)) {
+                        Write-Host 'Auto-switching: pinned (an explicit profile is active)'
+                        Write-Host "Run 'claude-profile auto on' to resume auto-switching."
+                    } else {
+                        Write-Host 'Auto-switching: enabled'
+                    }
+                    $Dotfile = Find-CPDotfile -StartDir (Get-CPCurrentFileSystemPath)
+                    if ($Dotfile) {
+                        $DotName = Read-CPDotfile -Path $Dotfile
+                        if (-not $DotName) { $DotName = '<empty>' }
+                        Write-Host "Directory profile: $DotName ($Dotfile)"
+                    } else {
+                        Write-Host 'Directory profile: none in scope'
+                    }
+                }
+                default {
+                    _cp_die 'usage: claude-profile auto [on|off|status]'
+                    return
+                }
+            }
+        }
+
+        'local' {
+            $Sub = if ($args.Count -gt 1) { $args[1] } else { $null }
+            $Cwd = Get-CPCurrentFileSystemPath
+            if (-not $Cwd) {
+                _cp_die 'the current location is not a filesystem directory'
+                return
+            }
+            $LocalFile = Join-Path $Cwd $Script:CPDotfileName
+            if (-not $Sub) {
+                $Dotfile = Find-CPDotfile -StartDir $Cwd
+                if (-not $Dotfile) {
+                    _cp_die "no $($Script:CPDotfileName) found in this directory or any parent"
+                    return
+                }
+                $DotName = Read-CPDotfile -Path $Dotfile
+                if (-not $DotName) { $DotName = '<empty>' }
+                Write-Host $Dotfile
+                Write-Host "Profile: $DotName"
+                return
+            }
+            if ($Sub -eq '--remove' -or $Sub -eq '--clear') {
+                if (-not (Test-Path -LiteralPath $LocalFile -PathType Leaf)) {
+                    _cp_die "no $($Script:CPDotfileName) in the current directory"
+                    return
+                }
+                Remove-Item -LiteralPath $LocalFile -Force
+                Write-Host "Removed $LocalFile"
+                $Script:CPAutoLastPwd = $null
+                Invoke-CPAutoSwitch
+                return
+            }
+            if ($Sub.StartsWith('-')) {
+                _cp_die "unknown option '$Sub'"
+                return
+            }
+            if ($args.Count -gt 2) {
+                _cp_die "unexpected argument after profile name: '$($args[2])'"
+                return
+            }
+            if (-not (_cp_validate_name $Sub)) { return }
+            $ProfileDir = Join-Path $DataDir $Sub
+            if (-not (Test-Path $ProfileDir -PathType Container)) {
+                _cp_die "profile '$Sub' does not exist. Create it with: claude-profile create $Sub"
+                return
+            }
+            [System.IO.File]::WriteAllText($LocalFile, "$Sub`n")
+            Write-Host "Wrote $LocalFile (profile: $Sub)"
+            $Script:CPAutoLastPwd = $null
+            Invoke-CPAutoSwitch
         }
 
         'create' {
@@ -533,10 +783,13 @@ Usage: claude-profile [command] [args...]
 
 Commands:
     (no command)            Show current profile status
-    use <name>              Switch session to the named profile
+    use <name>              Switch session to the named profile (pins it)
     create <name>           Create a new profile
     list, ls                List all profiles
     default [name]          Get or set the default profile
+    local [name]            Show, set (.claude-profile), or --remove the
+                            directory-local profile for the current directory
+    auto [on|off|status]    Control directory-local auto-switching
     which [name]            Show the resolved config directory path
     version                 Show the installed version
     update [--force]        Update to the latest release
@@ -546,12 +799,21 @@ Commands:
 The claude command automatically uses the default profile. Use
 'claude-profile use <name>' to override for the current session.
 
+A directory containing a .claude-profile file (holding a profile name)
+switches the session to that profile on Set-Location, and reverts on
+leaving. An explicit 'claude-profile use' pins the session and wins over
+any .claude-profile until 'claude-profile auto on'. Set
+CLAUDE_PROFILE_NO_AUTO_SWITCH=1 to disable, CLAUDE_PROFILE_AUTO_QUIET=1
+to switch silently.
+
 Examples:
     claude-profile create work
     claude-profile default work
     claude-profile use work
     claude                          # runs with "work" profile
     claude-profile                  # shows active/default status
+    claude-profile local work       # pin this directory tree to "work"
+    claude-profile local --remove   # drop the directory-local profile
 "@
         }
 
@@ -566,7 +828,15 @@ Examples:
                 }
             }
             if ($Active) {
-                Write-Host "Active profile: $Active"
+                $Dotfile = $null
+                if ($env:CLAUDE_CONFIG_DIR -eq $env:CLAUDE_PROFILE_AUTO_SET) {
+                    $Dotfile = Find-CPDotfile -StartDir (Get-CPCurrentFileSystemPath)
+                }
+                if ($Dotfile) {
+                    Write-Host "Active profile: $Active (from $Dotfile)"
+                } else {
+                    Write-Host "Active profile: $Active"
+                }
                 Write-Host "Config directory: $env:CLAUDE_CONFIG_DIR"
             } elseif ($env:CLAUDE_CONFIG_DIR) {
                 Write-Host "Active config directory: $env:CLAUDE_CONFIG_DIR (not a managed profile)"

--- a/claude-profile.cmd
+++ b/claude-profile.cmd
@@ -25,6 +25,7 @@ if "%~1"=="" goto :cmd_launch_default
 
 :: Command dispatch
 if "%~1"=="create"  goto :dispatch_create
+if "%~1"=="local"   goto :dispatch_local
 if "%~1"=="list"    goto :dispatch_list
 if "%~1"=="ls"      goto :dispatch_list
 if "%~1"=="default" goto :dispatch_default
@@ -53,6 +54,10 @@ exit /b 1
 :dispatch_create
 shift
 goto :cmd_create
+
+:dispatch_local
+shift
+goto :cmd_local
 
 :dispatch_list
 shift
@@ -271,11 +276,13 @@ goto :eof
 echo Usage: claude-profile [command] [args...]
 echo.
 echo Commands:
-echo     (no command)            Activate the default profile
+echo     (no command)            Activate the .claude-profile or default profile
 echo     use ^<name^>              Activate the named profile
 echo     create ^<name^>           Create a new profile
 echo     list, ls                List all profiles
 echo     default [name]          Get or set the default profile
+echo     local [name]            Show, set (.claude-profile), or --remove the
+echo                             directory-local profile for this directory
 echo     delete ^<name^>           Delete a profile
 echo     which [name]            Show the resolved config directory path
 echo     version                 Show the installed version
@@ -285,11 +292,18 @@ echo.
 echo Use 'call claude-profile use ^<name^>' to set CLAUDE_CONFIG_DIR in the
 echo current cmd session, then run 'claude' separately.
 echo.
+echo A directory containing a .claude-profile file (holding a profile name)
+echo is preferred over the default profile by a bare 'call claude-profile'.
+echo cmd.exe has no cd hook, so this resolves at invocation time rather than
+echo automatically on cd as it does in the sh and PowerShell versions.
+echo.
 echo Examples:
 echo     claude-profile create work
 echo     claude-profile default work
 echo     call claude-profile use work     # activates "work" profile
 echo     claude                           # runs with "work" profile
+echo     claude-profile local work        # write .claude-profile here
+echo     call claude-profile              # activates "work" from .claude-profile
 exit /b 0
 
 :: --- Validate name ---
@@ -329,7 +343,141 @@ echo !_vn_name!| findstr /R "^[a-zA-Z0-9_-][a-zA-Z0-9_-]*$" >nul 2>&1 || (
 
 goto :eof
 
+:: --- Directory-local profile (.claude-profile) ---
+::
+:: A directory may contain a `.claude-profile` file whose first non-empty,
+:: non-comment line names a profile. cmd.exe has no cd hook and no way to
+:: install a transparent `claude` wrapper, so unlike the sh and PowerShell
+:: implementations this cannot switch on cd. Instead, a bare
+:: `call claude-profile.cmd` resolves the nearest .claude-profile walking up
+:: from the current directory and prefers it over the default profile.
+
+:: Sets _fd_result to the nearest .claude-profile at or above %CD%, or leaves
+:: it empty when none is found.
+:find_dotfile
+set "_fd_result="
+set "_fd_dir=%CD%"
+:find_dotfile_loop
+if exist "!_fd_dir!\.claude-profile" (
+    set "_fd_result=!_fd_dir!\.claude-profile"
+    goto :eof
+)
+set "_fd_parent="
+for %%p in ("!_fd_dir!\..") do set "_fd_parent=%%~fp"
+if not defined _fd_parent goto :eof
+if /i "!_fd_parent!"=="!_fd_dir!" goto :eof
+set "_fd_dir=!_fd_parent!"
+goto :find_dotfile_loop
+
+:: Captures a literal CR into _CP_CR. `for /f` leaves the CR attached to each
+:: token when reading a CRLF file, which would otherwise make an otherwise
+:: valid profile name fail validation. Resolved lazily (only :read_dotfile
+:: needs it) so the common command paths don't pay for the copy.
+:capture_cr
+if defined _CP_CR goto :eof
+for /f %%a in ('copy /Z "%~f0" nul') do set "_CP_CR=%%a"
+goto :eof
+
+:: read_dotfile <path> -> sets _rd_name to the first non-empty, non-comment
+:: line, with surrounding whitespace and any trailing CR stripped.
+:read_dotfile
+call :capture_cr
+set "_rd_name="
+for /f "usebackq eol=# tokens=* delims=	 " %%L in ("%~1") do (
+    if not defined _rd_name set "_rd_name=%%L"
+)
+if not defined _rd_name goto :eof
+:read_dotfile_trim
+if not defined _rd_name goto :eof
+if "!_rd_name:~-1!"==" "       (set "_rd_name=!_rd_name:~0,-1!" & goto :read_dotfile_trim)
+if "!_rd_name:~-1!"=="	"      (set "_rd_name=!_rd_name:~0,-1!" & goto :read_dotfile_trim)
+if "!_rd_name:~-1!"=="!_CP_CR!" (set "_rd_name=!_rd_name:~0,-1!" & goto :read_dotfile_trim)
+goto :eof
+
+:: Resolves the directory-local profile into _dl_name / _dl_file, or leaves
+:: _dl_name empty. Reports (to stderr) a dotfile that names something
+:: unusable, so a typo isn't silently ignored.
+:resolve_dotfile_profile
+set "_dl_name="
+set "_dl_file="
+call :find_dotfile
+if not defined _fd_result goto :eof
+set "_dl_file=!_fd_result!"
+call :read_dotfile "!_dl_file!"
+if not defined _rd_name (
+    echo claude-profile: ignoring !_dl_file!: no profile name in file >&2
+    goto :eof
+)
+set "_vn_name=!_rd_name!"
+call :validate_name >nul 2>&1
+if errorlevel 1 (
+    echo claude-profile: ignoring !_dl_file!: invalid profile name '!_rd_name!' >&2
+    goto :eof
+)
+if not exist "%DATA_DIR%\!_rd_name!\" (
+    echo claude-profile: ignoring !_dl_file!: profile '!_rd_name!' does not exist >&2
+    goto :eof
+)
+set "_dl_name=!_rd_name!"
+goto :eof
+
 :: --- Commands ---
+
+:cmd_local
+if "%~1"=="" goto :cmd_local_show
+if /i "%~1"=="--remove" goto :cmd_local_remove
+if /i "%~1"=="--clear"  goto :cmd_local_remove
+set "_first=%~1"
+if "!_first:~0,1!"=="-" (
+    echo claude-profile: unknown option '%~1' >&2
+    exit /b 1
+)
+if not "%~2"=="" (
+    echo claude-profile: unexpected argument after profile name: '%~2' >&2
+    exit /b 1
+)
+set "_vn_name=%~1"
+call :validate_name
+if errorlevel 1 exit /b 1
+if not exist "%DATA_DIR%\%~1\" (
+    echo claude-profile: profile '%~1' does not exist. Create it with: claude-profile create %~1 >&2
+    exit /b 1
+)
+>"%CD%\.claude-profile" echo %~1
+if not exist "%CD%\.claude-profile" (
+    echo claude-profile: could not write %CD%\.claude-profile >&2
+    exit /b 1
+)
+echo Wrote %CD%\.claude-profile ^(profile: %~1^)
+echo Run 'call claude-profile.cmd' here to activate it.
+exit /b 0
+
+:cmd_local_show
+call :resolve_dotfile_profile
+if not defined _dl_file (
+    echo claude-profile: no .claude-profile found in this directory or any parent >&2
+    exit /b 1
+)
+echo !_dl_file!
+if defined _dl_name (
+    echo Profile: !_dl_name!
+) else (
+    exit /b 1
+)
+exit /b 0
+
+:cmd_local_remove
+if not exist "%CD%\.claude-profile" (
+    echo claude-profile: no .claude-profile in the current directory >&2
+    exit /b 1
+)
+del /f /q "%CD%\.claude-profile" >nul 2>&1
+if exist "%CD%\.claude-profile" (
+    echo claude-profile: could not remove %CD%\.claude-profile >&2
+    exit /b 1
+)
+echo Removed %CD%\.claude-profile
+exit /b 0
 
 :cmd_create
 if "%~1"=="" (
@@ -641,6 +789,10 @@ if exist "%DEFAULT_FILE%" (
 exit /b 0
 
 :cmd_launch_default
+:: A .claude-profile in this directory (or any parent) wins over the default.
+call :resolve_dotfile_profile
+if defined _dl_name goto :launch_dotfile
+
 :: Resolve default profile
 if not exist "%DEFAULT_FILE%" (
     echo claude-profile: no default profile set. Use: claude-profile default ^<name^> >&2
@@ -659,4 +811,14 @@ if not exist "!_rp_dir!\" (
 
 :: Set CLAUDE_CONFIG_DIR for the calling session (requires 'call' prefix)
 endlocal & set "CLAUDE_CONFIG_DIR=%_rp_dir%" & echo Switched to profile: %_rp_name% (default)
+exit /b 0
+
+:launch_dotfile
+:: Kept out of the `if defined` block above: `endlocal & set VAR=%...%`
+:: relies on percent-expansion happening after the preceding set lines have
+:: run, which a parenthesised block would break.
+set "_rp_name=%_dl_name%"
+set "_rp_dir=%DATA_DIR%\%_dl_name%"
+set "_rp_src=%_dl_file%"
+endlocal & set "CLAUDE_CONFIG_DIR=%_rp_dir%" & echo Switched to profile: %_rp_name% (from %_rp_src%)
 exit /b 0

--- a/claude-profile.sh
+++ b/claude-profile.sh
@@ -409,6 +409,152 @@ _cp_update_check() {
     return 0
 }
 
+# --- Directory-local profile (.claude-profile) auto-switching ---
+#
+# A directory may contain a `.claude-profile` file whose first non-empty,
+# non-comment line names a profile. Entering that directory (or any
+# descendant) switches CLAUDE_CONFIG_DIR to it; leaving reverts to the
+# default. Explicit `claude-profile use <name>` pins the session and
+# suppresses auto-switching until `claude-profile auto on`.
+#
+# Environment knobs:
+#   CLAUDE_PROFILE_NO_AUTO_SWITCH=1   disable auto-switching entirely
+#   CLAUDE_PROFILE_AUTO_QUIET=1       switch silently (no stderr notices)
+#
+# CLAUDE_PROFILE_AUTO_SET is exported so nested shells know the current
+# CLAUDE_CONFIG_DIR came from auto-switching (and may be re-managed) rather
+# than from an explicit `use`.
+
+_CP_DOTFILE=".claude-profile"
+_CP_CR=$(printf '\r')
+
+_cp_auto_notice() {
+    [ -n "${CLAUDE_PROFILE_AUTO_QUIET:-}" ] && return 0
+    printf 'claude-profile: %s\n' "$1" >&2
+    return 0
+}
+
+# Sets _cp_dotfile to the nearest .claude-profile at or above directory $1,
+# or empty when none is found. Deliberately uses only parameter expansion
+# (no dirname/basename subprocesses): this runs on every shell prompt under
+# bash's PROMPT_COMMAND, so a fork per path component would be felt.
+_cp_find_dotfile() {
+    _cp_dotfile=""
+    _cp_fd_dir="$1"
+    while :; do
+        [ -n "$_cp_fd_dir" ] || _cp_fd_dir="/"
+        if [ -f "${_cp_fd_dir%/}/${_CP_DOTFILE}" ]; then
+            _cp_dotfile="${_cp_fd_dir%/}/${_CP_DOTFILE}"
+            return 0
+        fi
+        [ "$_cp_fd_dir" = "/" ] && break
+        _cp_fd_dir="${_cp_fd_dir%/*}"
+    done
+    return 1
+}
+
+# Sets _cp_dotname to the first non-empty, non-comment line of file $1,
+# with surrounding whitespace and any trailing CR stripped (so a file
+# authored on Windows and used from WSL/Git Bash still resolves).
+_cp_read_dotfile() {
+    _cp_dotname=""
+    while IFS= read -r _cp_rd_line || [ -n "$_cp_rd_line" ]; do
+        _cp_rd_line="${_cp_rd_line%"$_CP_CR"}"
+        while :; do
+            case "$_cp_rd_line" in
+                " "*|"	"*) _cp_rd_line="${_cp_rd_line#?}" ;;
+                *" "|*"	") _cp_rd_line="${_cp_rd_line%?}" ;;
+                *) break ;;
+            esac
+        done
+        case "$_cp_rd_line" in
+            ''|'#'*) continue ;;
+        esac
+        _cp_dotname="$_cp_rd_line"
+        return 0
+    done < "$1"
+    return 1
+}
+
+# Resolves and applies the directory-local profile for $PWD. Safe to call
+# repeatedly: it short-circuits when the directory hasn't changed, which
+# also rate-limits the warnings below to once per directory entry rather
+# than once per prompt.
+_cp_auto_switch() {
+    [ -n "${CLAUDE_PROFILE_NO_AUTO_SWITCH:-}" ] && return 0
+    [ "${_CP_AUTO_OFF:-0}" = "1" ] && return 0
+    [ "${PWD:-}" = "${_CP_AUTO_LAST_PWD:-}" ] && return 0
+    _CP_AUTO_LAST_PWD="${PWD:-}"
+
+    # An explicitly-chosen profile (claude-profile use, or a CLAUDE_CONFIG_DIR
+    # inherited from outside) wins over any .claude-profile file.
+    if [ -n "${CLAUDE_CONFIG_DIR:-}" ] && [ "$CLAUDE_CONFIG_DIR" != "${CLAUDE_PROFILE_AUTO_SET:-}" ]; then
+        return 0
+    fi
+
+    _cp_dotname=""
+    if _cp_find_dotfile "${PWD:-}"; then
+        _cp_read_dotfile "$_cp_dotfile"
+    fi
+
+    if [ -z "$_cp_dotname" ]; then
+        if [ -n "${CLAUDE_PROFILE_AUTO_SET:-}" ]; then
+            unset CLAUDE_CONFIG_DIR
+            unset CLAUDE_PROFILE_AUTO_SET
+            _cp_auto_notice "directory profile cleared; using the default profile"
+        fi
+        [ -n "$_cp_dotfile" ] && _cp_die "ignoring ${_cp_dotfile}: no profile name in file"
+        return 0
+    fi
+
+    case "$_cp_dotname" in
+        .*|*..*|*/*|*\\*|*[!A-Za-z0-9_-]*)
+            _cp_die "ignoring ${_cp_dotfile}: invalid profile name '${_cp_dotname}'"
+            return 1
+            ;;
+    esac
+
+    [ -n "${_CP_DATA_CACHE:-}" ] || _CP_DATA_CACHE=$(_cp_data_dir)
+    _cp_as_dir="${_CP_DATA_CACHE}/${_cp_dotname}"
+    if [ ! -d "$_cp_as_dir" ]; then
+        _cp_die "ignoring ${_cp_dotfile}: profile '${_cp_dotname}' does not exist"
+        return 1
+    fi
+
+    if [ "${CLAUDE_CONFIG_DIR:-}" = "$_cp_as_dir" ]; then
+        export CLAUDE_PROFILE_AUTO_SET="$_cp_as_dir"
+        return 0
+    fi
+    export CLAUDE_CONFIG_DIR="$_cp_as_dir"
+    export CLAUDE_PROFILE_AUTO_SET="$_cp_as_dir"
+    _cp_auto_notice "profile '${_cp_dotname}' (from ${_cp_dotfile})"
+    return 0
+}
+
+# Registers _cp_auto_switch with whatever directory-change mechanism the
+# running shell offers. zsh has a real chpwd hook; bash only has
+# PROMPT_COMMAND; everything else (dash, ash, ksh) gets a cd wrapper, which
+# covers the common case even though it misses pushd/popd.
+if [ -n "${ZSH_VERSION:-}" ]; then
+    autoload -Uz add-zsh-hook 2>/dev/null && add-zsh-hook chpwd _cp_auto_switch
+elif [ -n "${BASH_VERSION:-}" ]; then
+    case "${PROMPT_COMMAND:-}" in
+        *_cp_auto_switch*) : ;;
+        '') PROMPT_COMMAND="_cp_auto_switch" ;;
+        *) PROMPT_COMMAND="${PROMPT_COMMAND%;};_cp_auto_switch" ;;
+    esac
+else
+    # `command cd` bypasses this function, so re-sourcing can't recurse.
+    cd() {
+        command cd "$@" || return $?
+        _cp_auto_switch
+    }
+fi
+
+# Resolve once at source time so a shell started inside a .claude-profile
+# tree is already on the right profile.
+_cp_auto_switch
+
 # --- claude() wrapper ---
 # Auto-resolves the default profile before calling the real claude binary.
 # If CLAUDE_CONFIG_DIR is already set (e.g. via 'claude-profile use'),
@@ -416,6 +562,9 @@ _cp_update_check() {
 
 claude() {
     _cp_update_check
+    # Covers shells whose cd we couldn't hook (and directory changes made by
+    # something other than cd) — resolving here is cheap and idempotent.
+    _cp_auto_switch
     if [ -z "${CLAUDE_CONFIG_DIR:-}" ]; then
         _cp_data=$(_cp_data_dir)
         _cp_def="${_cp_data}/.default"
@@ -423,6 +572,11 @@ claude() {
             _cp_name=$(cat "$_cp_def")
             if [ -n "$_cp_name" ] && [ -d "${_cp_data}/${_cp_name}" ]; then
                 export CLAUDE_CONFIG_DIR="${_cp_data}/${_cp_name}"
+                # Mark it auto-managed, not an explicit pin: without this, the
+                # first `claude` run would freeze the session on the default
+                # profile and later .claude-profile directories would be
+                # ignored.
+                export CLAUDE_PROFILE_AUTO_SET="$CLAUDE_CONFIG_DIR"
             fi
         fi
     fi
@@ -475,7 +629,98 @@ claude-profile() {
                 return 1
             fi
             export CLAUDE_CONFIG_DIR="$_cp_dir"
+            # Dropping the auto-set marker pins the session: subsequent
+            # directory changes will no longer override this choice.
+            unset CLAUDE_PROFILE_AUTO_SET
             printf 'Switched to profile: %s\n' "$_cp_name"
+            ;;
+
+        auto)
+            shift
+            case "${1:-}" in
+                on)
+                    unset _CP_AUTO_OFF
+                    unset CLAUDE_CONFIG_DIR
+                    unset CLAUDE_PROFILE_AUTO_SET
+                    _CP_AUTO_LAST_PWD=""
+                    _cp_auto_switch
+                    printf 'Directory-local auto-switching enabled.\n'
+                    ;;
+                off)
+                    _CP_AUTO_OFF=1
+                    printf 'Directory-local auto-switching disabled for this session.\n'
+                    ;;
+                ""|status)
+                    if [ -n "${CLAUDE_PROFILE_NO_AUTO_SWITCH:-}" ]; then
+                        printf 'Auto-switching: disabled (CLAUDE_PROFILE_NO_AUTO_SWITCH is set)\n'
+                    elif [ "${_CP_AUTO_OFF:-0}" = "1" ]; then
+                        printf 'Auto-switching: disabled for this session\n'
+                    elif [ -n "${CLAUDE_CONFIG_DIR:-}" ] && [ "$CLAUDE_CONFIG_DIR" != "${CLAUDE_PROFILE_AUTO_SET:-}" ]; then
+                        printf 'Auto-switching: pinned (an explicit profile is active)\n'
+                        printf "Run 'claude-profile auto on' to resume auto-switching.\\n"
+                    else
+                        printf 'Auto-switching: enabled\n'
+                    fi
+                    if _cp_find_dotfile "${PWD:-}"; then
+                        _cp_read_dotfile "$_cp_dotfile"
+                        printf 'Directory profile: %s (%s)\n' "${_cp_dotname:-<empty>}" "$_cp_dotfile"
+                    else
+                        printf 'Directory profile: none in scope\n'
+                    fi
+                    ;;
+                *)
+                    _cp_die "usage: claude-profile auto [on|off|status]"
+                    return 1
+                    ;;
+            esac
+            ;;
+
+        local)
+            shift
+            case "${1:-}" in
+                "")
+                    if _cp_find_dotfile "${PWD:-}"; then
+                        _cp_read_dotfile "$_cp_dotfile"
+                        printf '%s\n' "$_cp_dotfile"
+                        printf 'Profile: %s\n' "${_cp_dotname:-<empty>}"
+                    else
+                        _cp_die "no ${_CP_DOTFILE} found in this directory or any parent"
+                        return 1
+                    fi
+                    ;;
+                --remove|--clear)
+                    if [ ! -f "./${_CP_DOTFILE}" ]; then
+                        _cp_die "no ${_CP_DOTFILE} in the current directory"
+                        return 1
+                    fi
+                    rm -f "./${_CP_DOTFILE}" || return 1
+                    printf 'Removed %s\n' "${PWD}/${_CP_DOTFILE}"
+                    _CP_AUTO_LAST_PWD=""
+                    _cp_auto_switch
+                    ;;
+                -*)
+                    _cp_die "unknown option '$1'"
+                    return 1
+                    ;;
+                *)
+                    _cp_name="$1"
+                    shift
+                    if [ -n "${1:-}" ]; then
+                        _cp_die "unexpected argument after profile name: '$1'"
+                        return 1
+                    fi
+                    _cp_validate_name "$_cp_name" || return 1
+                    _cp_dir="${_cp_data}/${_cp_name}"
+                    if [ ! -d "$_cp_dir" ]; then
+                        _cp_die "profile '${_cp_name}' does not exist. Create it with: claude-profile create ${_cp_name}"
+                        return 1
+                    fi
+                    printf '%s\n' "$_cp_name" > "./${_CP_DOTFILE}" || return 1
+                    printf 'Wrote %s (profile: %s)\n' "${PWD}/${_CP_DOTFILE}" "$_cp_name"
+                    _CP_AUTO_LAST_PWD=""
+                    _cp_auto_switch
+                    ;;
+            esac
             ;;
 
         create)
@@ -708,10 +953,13 @@ Usage: claude-profile [command] [args...]
 
 Commands:
     (no command)            Show current profile status
-    use <name>              Switch session to the named profile
+    use <name>              Switch session to the named profile (pins it)
     create [--init] <name>  Create a new profile (--init writes a settings.json skeleton)
     list, ls                List all profiles
     default [name]          Get or set the default profile
+    local [name]            Show, set (.claude-profile), or --remove the
+                            directory-local profile for the current directory
+    auto [on|off|status]    Control directory-local auto-switching
     which [name]            Show the resolved config directory path
     version                 Show the installed version
     update [--force]        Update to the latest release
@@ -721,6 +969,13 @@ Commands:
 The claude command automatically uses the default profile. Use
 'claude-profile use <name>' to override for the current session.
 
+A directory containing a .claude-profile file (holding a profile name)
+switches the shell to that profile on cd, and reverts on leaving. An
+explicit 'claude-profile use' pins the session and wins over any
+.claude-profile until 'claude-profile auto on'. Set
+CLAUDE_PROFILE_NO_AUTO_SWITCH=1 to disable, CLAUDE_PROFILE_AUTO_QUIET=1
+to switch silently.
+
 Examples:
     claude-profile create work
     claude-profile create --init work
@@ -728,6 +983,8 @@ Examples:
     claude-profile use work
     claude                          # runs with "work" profile
     claude-profile                  # shows active/default status
+    claude-profile local work       # pin this directory tree to "work"
+    claude-profile local --remove   # drop the directory-local profile
 HELPEOF
             ;;
 
@@ -742,7 +999,11 @@ HELPEOF
                 esac
             fi
             if [ -n "$_cp_active" ]; then
-                printf 'Active profile: %s\n' "$_cp_active"
+                if [ "${CLAUDE_CONFIG_DIR:-}" = "${CLAUDE_PROFILE_AUTO_SET:-}" ] && _cp_find_dotfile "${PWD:-}"; then
+                    printf 'Active profile: %s (from %s)\n' "$_cp_active" "$_cp_dotfile"
+                else
+                    printf 'Active profile: %s\n' "$_cp_active"
+                fi
                 printf 'Config directory: %s\n' "$CLAUDE_CONFIG_DIR"
             elif [ -n "${CLAUDE_CONFIG_DIR:-}" ]; then
                 printf 'Active config directory: %s (not a managed profile)\n' "$CLAUDE_CONFIG_DIR"

--- a/docs/index.html
+++ b/docs/index.html
@@ -531,6 +531,14 @@
                 <td class="px-5 py-3 text-cream-300">Get or set the default profile</td>
               </tr>
               <tr class="cmd-row">
+                <td class="px-5 py-3 font-mono text-xs text-terra whitespace-nowrap">claude-profile local [name]</td>
+                <td class="px-5 py-3 text-cream-300">Show, set, or <span class="font-mono">--remove</span> this directory&rsquo;s <span class="font-mono">.claude-profile</span></td>
+              </tr>
+              <tr class="cmd-row">
+                <td class="px-5 py-3 font-mono text-xs text-terra whitespace-nowrap">claude-profile auto [on|off|status]</td>
+                <td class="px-5 py-3 text-cream-300">Control directory-local auto-switching</td>
+              </tr>
+              <tr class="cmd-row">
                 <td class="px-5 py-3 font-mono text-xs text-terra whitespace-nowrap">claude-profile which [name]</td>
                 <td class="px-5 py-3 text-cream-300">Show the config directory path</td>
               </tr>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -51,6 +51,8 @@ claude -p "explain this code"
 | `claude-profile create <name>` | Create a new profile |
 | `claude-profile list` | List all profiles |
 | `claude-profile default [name]` | Get or set the default profile |
+| `claude-profile local [name]` | Show, set, or `--remove` this directory's `.claude-profile` |
+| `claude-profile auto [on\|off\|status]` | Control directory-local auto-switching (not on cmd.exe) |
 | `claude-profile delete <name>` | Delete a profile (with confirmation) |
 | `claude-profile which [name]` | Show the config directory path |
 | `claude-profile help` | Show help |
@@ -59,9 +61,10 @@ claude -p "explain this code"
 
 Claude Code supports a `CLAUDE_CONFIG_DIR` environment variable that redirects where it stores configuration and data. claude-profile provides a `claude()` shell function that wraps the real `claude` binary:
 
-1. Before each invocation, the wrapper checks if a default profile exists and auto-sets `CLAUDE_CONFIG_DIR`.
-2. If `CLAUDE_CONFIG_DIR` is already set (e.g., via `claude-profile use`), it is used as-is.
-3. The real `claude` binary is then called with all your arguments.
+1. On each directory change, the nearest `.claude-profile` file (if any) sets `CLAUDE_CONFIG_DIR`.
+2. Before each invocation, the wrapper checks if a default profile exists and auto-sets `CLAUDE_CONFIG_DIR`.
+3. If `CLAUDE_CONFIG_DIR` is already set (e.g., via `claude-profile use`), it is used as-is.
+4. The real `claude` binary is then called with all your arguments.
 
 This means you never need to think about profiles during normal use — just run `claude` as you always have.
 
@@ -75,6 +78,21 @@ claude                          # uses "personal" for this shell session
 ```
 
 The override lasts until you close the shell or run `claude-profile use` again.
+
+### Per-Directory Profiles
+
+A directory can pin itself (and everything under it) to a profile by holding a `.claude-profile` file whose first non-empty, non-comment line is a profile name:
+
+```
+cd ~/work/acme
+claude-profile local work        # writes ./.claude-profile containing "work"
+```
+
+Your shell then switches to `work` whenever you `cd` into that tree, and back to the default when you leave. The file is plain text, so it can be committed to a repo; blank lines and `#` comments are ignored.
+
+An explicit `claude-profile use <name>` pins the session and wins over any `.claude-profile` until `claude-profile auto on`. `claude-profile auto off` disables auto-switching for the session, and `claude-profile auto status` shows what is in effect. Set `CLAUDE_PROFILE_NO_AUTO_SWITCH=1` to disable it entirely, or `CLAUDE_PROFILE_AUTO_QUIET=1` to switch silently.
+
+Hooking into directory changes is per-shell: zsh uses `chpwd`, bash uses `PROMPT_COMMAND`, and other POSIX shells get a `cd` wrapper. PowerShell 6+ uses `LocationChangedAction`; Windows PowerShell 5.1 hooks the `prompt` function. cmd.exe has neither a `cd` hook nor a transparent `claude` wrapper, so it cannot switch automatically — instead a bare `call claude-profile.cmd` prefers the nearest `.claude-profile` over the default profile.
 
 ### Profile Storage
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -24,6 +24,8 @@ Each profile is a complete, isolated Claude Code configuration directory contain
 - `claude-profile list`: List all profiles
 - `claude-profile default [name]`: Get or set the default profile
 - `claude-profile use <name>`: Switch to a profile for the current shell session
+- `claude-profile local [name]`: Show, set, or `--remove` this directory's `.claude-profile`
+- `claude-profile auto [on|off|status]`: Control directory-local auto-switching
 - `claude-profile which [name]`: Show the config directory path
 - `claude-profile delete <name>`: Delete a profile (with confirmation)
 - `claude-profile help`: Show help


### PR DESCRIPTION
## Summary

A directory (and everything under it) can pin itself to a profile by holding a `.claude-profile` file whose first non-empty, non-comment line names the profile. Entering the tree switches `CLAUDE_CONFIG_DIR`; leaving reverts to the default.

```
$ cd ~/work/acme/api
claude-profile: profile 'work' (from /home/you/work/acme/.claude-profile)
$ cd ~
claude-profile: directory profile cleared; using the default profile
```

## Precedence

Ownership is tracked via an exported `CLAUDE_PROFILE_AUTO_SET` marker: auto-switching only manages `CLAUDE_CONFIG_DIR` when its value equals that marker, so `claude-profile use` (or a value inherited from outside) pins the session until `claude-profile auto on`. Exporting it means nested shells keep auto-managing rather than treating the inherited value as manual.

`claude()`'s own default-profile fallback sets the marker too — without that, the first `claude` invocation would freeze the session on the default profile and every later `.claude-profile` would be ignored. That was a real bug caught during testing.

## New commands

- `claude-profile local [name|--remove]` — show, set, or delete this directory's `.claude-profile` (all three implementations)
- `claude-profile auto [on|off|status]` — control auto-switching (sh, ps1)
- Knobs: `CLAUDE_PROFILE_NO_AUTO_SWITCH=1`, `CLAUDE_PROFILE_AUTO_QUIET=1`

## Per-shell hooks

zsh `chpwd`, bash `PROMPT_COMMAND`, a `cd` wrapper elsewhere; PowerShell 6+ `LocationChangedAction`, PowerShell 5.1 a `prompt` wrapper. `claude()` also re-resolves as a backstop.

Because bash re-runs the resolver on every prompt, it short-circuits on unchanged `$PWD` and the upward walk uses only parameter expansion (no `dirname` fork per path component). That short-circuit also rate-limits the invalid-dotfile warnings to once per directory entry.

cmd.exe has no `cd` hook and no `claude` wrapper, so it can't switch automatically — a bare `call claude-profile.cmd` resolves the dotfile at invocation time and prefers it over the default.

## Verification

`shellcheck` clean; `checkbashisms` reports only the two pre-existing expected items (guarded `$BASH_VERSION` test, hyphenated function name).

Tested in bash and zsh, plus the `cd`-wrapper fallback path (forced, since no dash/ash/ksh is installed in the dev environment): entering/leaving trees, nested subdirectories, comment/blank-line/whitespace handling, pinning via `use`, `auto on/off/status`, `local` write/show/remove, invalid and nonexistent profile names, re-sourcing, and nested-shell inheritance.

**Not executed:** the PowerShell and cmd paths — neither `pwsh` nor `cmd.exe` is available in the dev environment. Both were reviewed by hand (balanced braces, label flow, `endlocal & set` percent-expansion kept out of a parenthesised block, literal tabs present in the cmd parser), but they have not been run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)