### PR TITLE
feat: per-profile skill selection via a shared skill pool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ All three implementations share the same command interface:
 | `claude-profile default [name]` | Get or set the default profile |
 | `claude-profile local [name]` | Show, set, or `--remove` the directory-local `.claude-profile` |
 | `claude-profile auto [on\|off\|status]` | Control directory-local auto-switching (sh/ps1 only) |
+| `claude-profile skills ...` | Manage the shared skill pool and per-profile selections (see below) |
 | `claude-profile which [name]` | Show the resolved config directory path |
 | `claude-profile delete <name>` | Delete a profile (with confirmation) |
 | `claude-profile help` | Show help |
@@ -46,6 +47,33 @@ The pin is tracked via an exported `CLAUDE_PROFILE_AUTO_SET` marker: auto-switch
 Directory-change hooks differ per shell: zsh `chpwd`, bash `PROMPT_COMMAND`, `cd` wrapper elsewhere; PowerShell 6+ `LocationChangedAction`, PowerShell 5.1 `prompt` wrapper. cmd.exe has no hook — a bare `call claude-profile.cmd` resolves the dotfile at invocation time instead.
 
 Because bash re-runs the resolver on every prompt, `_cp_auto_switch` short-circuits when `$PWD` is unchanged and the upward walk uses only parameter expansion (no `dirname` fork per component). That short-circuit also rate-limits the "invalid/missing profile" warnings to once per directory entry.
+
+## Per-Profile Skills
+
+A shared skill pool lives at `<data-root>/skills/` (the profile name
+`skills` is therefore reserved and rejected by validation in all three
+implementations, including the `.claude-profile` resolvers). `skills
+register <name> <path>` links a skill source directory (must contain
+`SKILL.md`) into the pool — `ln -s` on POSIX, directory junctions
+(`mklink /J`, no admin rights) on Windows including via Git Bash
+(`cmd //c mklink /J` + `cygpath -w`) so all three implementations share
+the links.
+
+Each profile may have a `skills.conf` manifest (one pool-skill name per
+line, `#` comments, same parser style as `.claude-profile`). Absent
+manifest = all pool skills (backward-compatible default); empty manifest
+= none. `skills add`/`remove` first materialize the implicit "all" list
+into `skills.conf` so edits stay sticky.
+
+Sync (`skills sync`, also run by `create` and every manifest-editing
+command) is two-pass: remove managed links that are dangling or
+undesired, then create missing ones. A link is *managed* iff its literal
+target lies under the pool directory — anything else in
+`<profile>/skills/` (hand-made symlinks, real dirs) is never touched;
+name collisions warn and the unmanaged entry wins. Sync never runs on
+`use` or the auto-switch hot path. In cmd, link targets are read by
+parsing `dir /AL` output and managed detection is an exact-target
+comparison against `<pool>\<name>`.
 
 ## Validation Rules
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ claude -p "explain this code"
 | `claude-profile default [name]` | Get or set the default profile |
 | `claude-profile local [name]` | Show, set, or `--remove` this directory's `.claude-profile` |
 | `claude-profile auto [on\|off\|status]` | Control directory-local auto-switching (not on cmd.exe) |
+| `claude-profile skills` | List pool skills and their status for the profile |
+| `claude-profile skills register <name> <path>` | Add a skill directory to the shared pool |
+| `claude-profile skills unregister [--force] <name>` | Remove a skill from the pool |
+| `claude-profile skills add <skill> [profile]` | Add a pool skill to a profile |
+| `claude-profile skills remove <skill> [profile]` | Remove a pool skill from a profile |
+| `claude-profile skills set <s1,s2,...> [profile]` | Replace a profile's skill selection |
+| `claude-profile skills reset [profile]` | Back to the default (all pool skills) |
+| `claude-profile skills sync [profile\|--all]` | Re-materialize skill links |
 | `claude-profile delete <name>` | Delete a profile (with confirmation) |
 | `claude-profile which [name]` | Show the config directory path |
 | `claude-profile version` | Show the installed version |
@@ -134,6 +142,52 @@ claude-profile local work
 call claude-profile
 claude
 ```
+
+### Per-Profile Skills
+
+Skills usually have to be curated by hand per config directory. `claude-profile`
+can instead manage them from a **shared pool** at `<data-dir>/skills/`
+(next to your profile directories), with each profile selecting the subset
+it wants — so a `backend` profile only loads backend skills, keeping
+context lean:
+
+```sh
+# Register skills into the pool (each path must contain a SKILL.md)
+claude-profile skills register api-design ~/skills/api-design
+claude-profile skills register ui-design  ~/skills/ui-design
+
+# Pick subsets per profile
+claude-profile skills set api-design backend
+claude-profile skills set ui-design frontend
+
+# Or tweak incrementally
+claude-profile skills add ui-design backend
+claude-profile skills remove ui-design backend
+```
+
+How it works:
+
+- Registering creates a symlink (a directory **junction** on Windows — no
+  admin rights needed) in the pool; the pool entry name is what profiles
+  refer to.
+- A profile's selection lives in `<profile>/skills.conf` — plain text, one
+  skill name per line, `#` comments allowed. **No `skills.conf` means the
+  profile gets every pool skill**, so existing profiles keep working
+  unchanged. An empty file means none.
+- Syncing materializes the selection as links in `<profile>/skills/`. The
+  tool only ever creates or removes links that point into the pool —
+  hand-made symlinks, real directories, and files in `<profile>/skills/`
+  are never touched (a name collision is reported and the unmanaged entry
+  wins).
+- Links update only when you run a `skills` command (or at
+  `claude-profile create`) — switching profiles does no filesystem work.
+  After registering or unregistering pool skills, run
+  `claude-profile skills sync --all` to propagate.
+- The profile name `skills` is reserved for the pool directory.
+
+`claude-profile` status and `list` output annotate filtered profiles, e.g.
+`skills: 3/12 (filtered)`. (cmd.exe has no bare status command, so there
+the annotation appears in `list` only.)
 
 ### Profile Storage
 

--- a/README.md
+++ b/README.md
@@ -185,9 +185,10 @@ How it works:
   `claude-profile skills sync --all` to propagate.
 - The profile name `skills` is reserved for the pool directory.
 
-`claude-profile` status and `list` output annotate filtered profiles, e.g.
-`skills: 3/12 (filtered)`. (cmd.exe has no bare status command, so there
-the annotation appears in `list` only.)
+Filtered profiles are annotated in `claude-profile list` (e.g.
+`work [skills: 3/12]`) and in the bare `claude-profile` status output
+(`Skills: 3 of 12 pool skills (filtered)`). (cmd.exe has no bare status
+command, so there the annotation appears in `list` only.)
 
 ### Profile Storage
 

--- a/claude-profile-init.ps1
+++ b/claude-profile-init.ps1
@@ -470,7 +470,7 @@ function Get-CPDesiredSkills {
 # Without this, pool operations would enumerate its internals as skills
 # and link them into every profile.
 function Test-CPPoolGuard {
-    $poolDir = Join-Path (Get-CPDataDir) 'skills'
+    $poolDir = Get-CPSkillPoolDir
     if (-not (Test-Path -LiteralPath $poolDir -PathType Container)) { return $true }
     if ((Test-Path -LiteralPath (Join-Path $poolDir 'settings.json') -PathType Leaf) -or
         (Test-Path -LiteralPath (Join-Path $poolDir '.credentials.json') -PathType Leaf)) {
@@ -485,7 +485,7 @@ function Test-CPPoolGuard {
 function Sync-CPProfileSkills {
     param([string]$Name)
     $dataDir = Get-CPDataDir
-    $poolDir = Join-Path $dataDir 'skills'
+    $poolDir = Get-CPSkillPoolDir
     $profileDir = Join-Path $dataDir $Name
     $skillsDir = Join-Path $profileDir 'skills'
     if (-not (Test-CPPoolGuard)) { return $false }
@@ -653,7 +653,15 @@ function claude-profile {
         } elseif ($env:CLAUDE_CONFIG_DIR) {
             $normalized = $env:CLAUDE_CONFIG_DIR.Replace('\', '/')
             $normalizedData = $DataDir.Replace('\', '/')
-            if ($normalized.StartsWith("$normalizedData/")) {
+            # Case-insensitive on Windows: CLAUDE_CONFIG_DIR may be
+            # inherited from a cmd/Git Bash session with different
+            # %LOCALAPPDATA% casing.
+            $cmp = if ($IsWindows -or ($PSVersionTable.PSEdition -eq 'Desktop')) {
+                [System.StringComparison]::OrdinalIgnoreCase
+            } else {
+                [System.StringComparison]::Ordinal
+            }
+            if ($normalized.StartsWith("$normalizedData/", $cmp)) {
                 $name = Split-Path $env:CLAUDE_CONFIG_DIR -Leaf
             } else {
                 _cp_die 'active CLAUDE_CONFIG_DIR is not a managed profile; pass a profile name'
@@ -814,7 +822,7 @@ function claude-profile {
             Write-Host "Config directory: $ProfileDir"
             # A new profile has no manifest, so this links every pool skill
             # (the backward-compatible "all" default). No pool: no-op.
-            if (Test-Path (Join-Path $DataDir 'skills') -PathType Container) {
+            if (Test-Path (Get-CPSkillPoolDir) -PathType Container) {
                 Sync-CPProfileSkills -Name $ArgName | Out-Null
             }
         }
@@ -843,7 +851,7 @@ function claude-profile {
                 Write-Host 'No profiles found. Create one with: claude-profile create <name>'
                 return
             }
-            $PoolCount = @(Get-CPPoolSkills -PoolDir (Join-Path $DataDir 'skills')).Count
+            $PoolCount = @(Get-CPPoolSkills -PoolDir (Get-CPSkillPoolDir)).Count
             foreach ($Entry in $Entries) {
                 $SkillNote = ''
                 $Manifest = Join-Path $Entry.FullName 'skills.conf'
@@ -963,7 +971,7 @@ function claude-profile {
         }
 
         'skills' {
-            $PoolDir = Join-Path $DataDir 'skills'
+            $PoolDir = Get-CPSkillPoolDir
             if (-not (Test-CPPoolGuard)) { return }
             $Sub = if ($args.Count -gt 1) { $args[1] } else { $null }
             switch ($Sub) {
@@ -989,7 +997,10 @@ function claude-profile {
                     }
                     New-Item -ItemType Directory -Path $PoolDir -Force | Out-Null
                     $PoolEntry = Join-Path $PoolDir $SkillName
-                    if (Test-Path -LiteralPath $PoolEntry) {
+                    # Get-Item -Force sees dangling junctions too, which
+                    # plain Test-Path resolves (to $false) and would let
+                    # fall through to a misleading link-creation failure.
+                    if (Get-Item -LiteralPath $PoolEntry -Force -ErrorAction SilentlyContinue) {
                         _cp_die "skill '$SkillName' is already registered"
                         return
                     }
@@ -1006,6 +1017,12 @@ function claude-profile {
                     $Rest = @($args | Select-Object -Skip 2)
                     $Force = $Rest -contains '--force'
                     $Names = @($Rest | Where-Object { $_ -ne '--force' })
+                    foreach ($Token in $Names) {
+                        if ("$Token".StartsWith('-')) {
+                            _cp_die "unknown option '$Token'"
+                            return
+                        }
+                    }
                     if ($Names.Count -ne 1) {
                         _cp_die 'usage: claude-profile skills unregister [--force] <name>'
                         return
@@ -1371,7 +1388,7 @@ Examples:
             }
             # Skills annotation for the active (else default) profile;
             # silent until a skill pool exists.
-            $PoolDir = Join-Path $DataDir 'skills'
+            $PoolDir = Get-CPSkillPoolDir
             if (Test-Path -LiteralPath $PoolDir -PathType Container) {
                 $SkillProfile = if ($Active) { $Active } else { $CurDefault }
                 if ($SkillProfile -and (Test-Path (Join-Path $DataDir $SkillProfile) -PathType Container)) {

--- a/claude-profile-init.ps1
+++ b/claude-profile-init.ps1
@@ -290,7 +290,7 @@ function Invoke-CPAutoSwitch {
             return
         }
 
-        if ($name -notmatch '^[A-Za-z0-9_-]+$') {
+        if ($name -notmatch '^[A-Za-z0-9_-]+$' -or $name -eq 'skills') {
             $host.UI.WriteErrorLine("claude-profile: ignoring ${dotfile}: invalid profile name '$name'")
             return
         }
@@ -340,6 +340,176 @@ if (-not $Script:CPLocationHookInstalled) {
 # Resolve once at load time so a session started inside a .claude-profile
 # tree is already on the right profile.
 Invoke-CPAutoSwitch
+
+# --- Skill pool helpers ---
+#
+# A central pool at <data-root>/skills holds registered skills (directories
+# or links to skill source directories). Each profile may carry a
+# skills.conf manifest (one pool-skill name per line, # comments) naming
+# the subset it wants; no manifest means every pool skill. Sync
+# materializes the selection as links in <profile>/skills. Only links
+# whose target lies under the pool are ever created or removed — hand-made
+# links, real directories, and files are left alone.
+
+function Get-CPSkillPoolDir {
+    return Join-Path (Get-CPDataDir) 'skills'
+}
+
+# Creates a link at $Dest pointing to directory $Source: a directory
+# junction on Windows (no admin rights needed, readable by the cmd and sh
+# implementations), a symlink elsewhere. Returns $true on success.
+function New-CPSkillLink {
+    param([string]$Source, [string]$Dest)
+    try {
+        if ($IsWindows -or ($PSVersionTable.PSEdition -eq 'Desktop')) {
+            New-Item -ItemType Junction -Path $Dest -Target $Source -ErrorAction Stop | Out-Null
+        } else {
+            New-Item -ItemType SymbolicLink -Path $Dest -Target $Source -ErrorAction Stop | Out-Null
+        }
+        return $true
+    } catch {
+        return $false
+    }
+}
+
+# Returns the literal link target of $Path, or $null when it is not a
+# link (junction or symlink).
+function Get-CPLinkTarget {
+    param([string]$Path)
+    try {
+        $item = Get-Item -LiteralPath $Path -Force -ErrorAction Stop
+    } catch {
+        return $null
+    }
+    if (-not $item.LinkType) { return $null }
+    $target = @($item.Target) | Select-Object -First 1
+    if ($target) { return [string]$target }
+    return $null
+}
+
+# Removes a link without touching its target. FileSystemInfo.Delete() is
+# non-recursive, so on a junction it removes only the reparse point.
+function Remove-CPSkillLink {
+    param([string]$Path)
+    try {
+        (Get-Item -LiteralPath $Path -Force -ErrorAction Stop).Delete()
+        return $true
+    } catch {
+        try {
+            Remove-Item -LiteralPath $Path -Force -ErrorAction Stop
+            return $true
+        } catch {
+            return $false
+        }
+    }
+}
+
+# Returns $true when the link at $Path is managed, i.e. its target lies
+# under the pool directory.
+function Test-CPManagedSkillLink {
+    param([string]$Path, [string]$PoolDir)
+    $target = Get-CPLinkTarget -Path $Path
+    if (-not $target) { return $false }
+    $normTarget = $target.Replace('\', '/').TrimEnd('/')
+    $normPool = $PoolDir.Replace('\', '/').TrimEnd('/')
+    return $normTarget.StartsWith("$normPool/")
+}
+
+# Returns the valid skill names from manifest file $Path. Blank lines and
+# # comments are skipped; invalid names warn and are skipped so one bad
+# line never fails a whole sync.
+function Read-CPSkillManifest {
+    param([string]$Path)
+    $names = @()
+    try {
+        $lines = @(Get-Content -LiteralPath $Path -ErrorAction Stop)
+    } catch {
+        return $names
+    }
+    foreach ($line in $lines) {
+        $trimmed = $line.Trim()
+        if (-not $trimmed) { continue }
+        if ($trimmed.StartsWith('#')) { continue }
+        if ($trimmed -notmatch '^[A-Za-z0-9_-]+$') {
+            $host.UI.WriteErrorLine("claude-profile: skills.conf: ignoring invalid skill name '$trimmed'")
+            continue
+        }
+        $names += $trimmed
+    }
+    return $names
+}
+
+# Returns the names of every skill registered in the pool, including
+# dangling registrations (link whose source is gone) so listings can
+# report them and sync can warn.
+function Get-CPPoolSkills {
+    param([string]$PoolDir)
+    if (-not (Test-Path -LiteralPath $PoolDir -PathType Container)) { return @() }
+    return @(Get-ChildItem -LiteralPath $PoolDir -Force -ErrorAction SilentlyContinue |
+        Where-Object { $_.PSIsContainer -or $_.LinkType } |
+        ForEach-Object { $_.Name })
+}
+
+# Returns the desired skill set for a profile: the manifest names when
+# skills.conf exists, every pool skill otherwise.
+function Get-CPDesiredSkills {
+    param([string]$ProfileDir, [string]$PoolDir)
+    $manifest = Join-Path $ProfileDir 'skills.conf'
+    if (Test-Path -LiteralPath $manifest -PathType Leaf) {
+        return @(Read-CPSkillManifest -Path $manifest)
+    }
+    return @(Get-CPPoolSkills -PoolDir $PoolDir)
+}
+
+# Re-materializes managed skill links for profile $Name from its manifest
+# (or the whole pool when no manifest).
+function Sync-CPProfileSkills {
+    param([string]$Name)
+    $dataDir = Get-CPDataDir
+    $poolDir = Join-Path $dataDir 'skills'
+    $profileDir = Join-Path $dataDir $Name
+    $skillsDir = Join-Path $profileDir 'skills'
+    $desired = @(Get-CPDesiredSkills -ProfileDir $profileDir -PoolDir $poolDir)
+    try {
+        New-Item -ItemType Directory -Path $skillsDir -Force -ErrorAction Stop | Out-Null
+    } catch {
+        $host.UI.WriteErrorLine("claude-profile: cannot create $skillsDir")
+        return $false
+    }
+
+    # Pass 1: drop managed links that are dangling or no longer desired.
+    foreach ($entry in @(Get-ChildItem -LiteralPath $skillsDir -Force -ErrorAction SilentlyContinue)) {
+        if (-not $entry.LinkType) { continue }
+        if (-not (Test-CPManagedSkillLink -Path $entry.FullName -PoolDir $poolDir)) { continue }
+        $poolEntry = Join-Path $poolDir $entry.Name
+        if (($desired -notcontains $entry.Name) -or
+            -not (Test-Path -LiteralPath $poolEntry -PathType Container)) {
+            if (-not (Remove-CPSkillLink -Path $entry.FullName)) {
+                $host.UI.WriteErrorLine("claude-profile: could not remove $($entry.FullName)")
+            }
+        }
+    }
+
+    # Pass 2: create links missing from the desired set.
+    foreach ($want in $desired) {
+        $poolEntry = Join-Path $poolDir $want
+        if (-not (Test-Path -LiteralPath $poolEntry -PathType Container)) {
+            $host.UI.WriteErrorLine("claude-profile: skill '$want' is not in the pool (or its source is gone); skipping")
+            continue
+        }
+        $dest = Join-Path $skillsDir $want
+        if (Test-Path -LiteralPath $dest) {
+            if (-not (Test-CPManagedSkillLink -Path $dest -PoolDir $poolDir)) {
+                $host.UI.WriteErrorLine("claude-profile: skill '$want': unmanaged entry already at $dest; skipping")
+            }
+            continue
+        }
+        if (-not (New-CPSkillLink -Source $poolEntry -Dest $dest)) {
+            $host.UI.WriteErrorLine("claude-profile: could not link skill '$want'")
+        }
+    }
+    return $true
+}
 
 # --- claude wrapper ---
 # Auto-resolves the default profile before calling the real claude binary.
@@ -420,7 +590,59 @@ function claude-profile {
             _cp_die "invalid profile name '$Name': use only letters, digits, hyphens, underscores"
             return $false
         }
+        if ($Name -eq 'skills') {
+            _cp_die "profile name 'skills' is reserved for the skill pool"
+            return $false
+        }
         return $true
+    }
+
+    function _cp_validate_skill_name {
+        param([string]$Name)
+        if ([string]::IsNullOrEmpty($Name)) {
+            _cp_die 'skill name must not be empty'
+            return $false
+        }
+        if ($Name -notmatch '^[A-Za-z0-9_-]+$') {
+            _cp_die "invalid skill name '$Name': use only letters, digits, hyphens, underscores"
+            return $false
+        }
+        return $true
+    }
+
+    # Resolves the profile a skills command acts on: the explicit argument
+    # if given, else the active profile, else the default. Returns the
+    # profile name, or $null after printing an error.
+    function _cp_skills_profile {
+        param([string]$ArgName)
+        $name = $null
+        if ($ArgName) {
+            if (-not (_cp_validate_name $ArgName)) { return $null }
+            $name = $ArgName
+        } elseif ($env:CLAUDE_CONFIG_DIR) {
+            $normalized = $env:CLAUDE_CONFIG_DIR.Replace('\', '/')
+            $normalizedData = $DataDir.Replace('\', '/')
+            if ($normalized.StartsWith("$normalizedData/")) {
+                $name = Split-Path $env:CLAUDE_CONFIG_DIR -Leaf
+            } else {
+                _cp_die 'active CLAUDE_CONFIG_DIR is not a managed profile; pass a profile name'
+                return $null
+            }
+        } elseif (Test-Path $DefaultFile) {
+            $name = (Get-Content $DefaultFile -Raw).Trim()
+            if (-not $name) {
+                _cp_die 'no profile specified and no default profile set'
+                return $null
+            }
+        } else {
+            _cp_die 'no profile specified and no default profile set'
+            return $null
+        }
+        if (-not (Test-Path (Join-Path $DataDir $name) -PathType Container)) {
+            _cp_die "profile '$name' does not exist"
+            return $null
+        }
+        return $name
     }
 
     # --- Command dispatch ---
@@ -559,6 +781,11 @@ function claude-profile {
             New-Item -ItemType Directory -Path $ProfileDir -Force | Out-Null
             Write-Host "Created profile: $ArgName"
             Write-Host "Config directory: $ProfileDir"
+            # A new profile has no manifest, so this links every pool skill
+            # (the backward-compatible "all" default). No pool: no-op.
+            if (Test-Path (Join-Path $DataDir 'skills') -PathType Container) {
+                Sync-CPProfileSkills -Name $ArgName | Out-Null
+            }
         }
 
         { $_ -eq 'list' -or $_ -eq 'ls' } {
@@ -579,22 +806,30 @@ function claude-profile {
                     $Active = Split-Path $env:CLAUDE_CONFIG_DIR -Leaf
                 }
             }
-            $Entries = Get-ChildItem -Path $DataDir -Directory -ErrorAction SilentlyContinue
+            $Entries = @(Get-ChildItem -Path $DataDir -Directory -ErrorAction SilentlyContinue |
+                Where-Object { $_.Name -ne 'skills' })
             if (-not $Entries -or $Entries.Count -eq 0) {
                 Write-Host 'No profiles found. Create one with: claude-profile create <name>'
                 return
             }
+            $PoolCount = @(Get-CPPoolSkills -PoolDir (Join-Path $DataDir 'skills')).Count
             foreach ($Entry in $Entries) {
+                $SkillNote = ''
+                $Manifest = Join-Path $Entry.FullName 'skills.conf'
+                if (Test-Path -LiteralPath $Manifest -PathType Leaf) {
+                    $SkillCount = @(Read-CPSkillManifest -Path $Manifest).Count
+                    $SkillNote = " [skills: $SkillCount/$PoolCount]"
+                }
                 $IsDefault = ($Entry.Name -eq $CurDefault)
                 $IsActive = ($Entry.Name -eq $Active)
                 if ($IsDefault -and $IsActive) {
-                    Write-Host ">* $($Entry.Name) (default, active)"
+                    Write-Host ">* $($Entry.Name) (default, active)$SkillNote"
                 } elseif ($IsDefault) {
-                    Write-Host " * $($Entry.Name) (default)"
+                    Write-Host " * $($Entry.Name) (default)$SkillNote"
                 } elseif ($IsActive) {
-                    Write-Host ">  $($Entry.Name) (active)"
+                    Write-Host ">  $($Entry.Name) (active)$SkillNote"
                 } else {
-                    Write-Host "   $($Entry.Name)"
+                    Write-Host "   $($Entry.Name)$SkillNote"
                 }
             }
         }
@@ -696,6 +931,235 @@ function claude-profile {
             }
         }
 
+        'skills' {
+            $PoolDir = Join-Path $DataDir 'skills'
+            $Sub = if ($args.Count -gt 1) { $args[1] } else { $null }
+            switch ($Sub) {
+                'register' {
+                    $SkillName = if ($args.Count -gt 2) { $args[2] } else { $null }
+                    $SkillPath = if ($args.Count -gt 3) { $args[3] } else { $null }
+                    if (-not $SkillName -or -not $SkillPath) {
+                        _cp_die 'usage: claude-profile skills register <name> <path>'
+                        return
+                    }
+                    if ($args.Count -gt 4) {
+                        _cp_die "unexpected argument '$($args[4])'"
+                        return
+                    }
+                    if (-not (_cp_validate_skill_name $SkillName)) { return }
+                    if (-not (Test-Path -LiteralPath $SkillPath -PathType Container)) {
+                        _cp_die "'$SkillPath' is not a directory"
+                        return
+                    }
+                    if (-not (Test-Path -LiteralPath (Join-Path $SkillPath 'SKILL.md') -PathType Leaf)) {
+                        _cp_die "'$SkillPath' does not contain a SKILL.md"
+                        return
+                    }
+                    New-Item -ItemType Directory -Path $PoolDir -Force | Out-Null
+                    $PoolEntry = Join-Path $PoolDir $SkillName
+                    if (Test-Path -LiteralPath $PoolEntry) {
+                        _cp_die "skill '$SkillName' is already registered"
+                        return
+                    }
+                    $AbsPath = (Resolve-Path -LiteralPath $SkillPath).ProviderPath
+                    if (-not (New-CPSkillLink -Source $AbsPath -Dest $PoolEntry)) {
+                        _cp_die "could not create pool link for '$SkillName'"
+                        return
+                    }
+                    Write-Host "Registered skill: $SkillName -> $AbsPath"
+                    Write-Host "Run 'claude-profile skills sync --all' to link it into unfiltered profiles."
+                }
+
+                'unregister' {
+                    $Rest = @($args | Select-Object -Skip 2)
+                    $Force = $Rest -contains '--force'
+                    $Names = @($Rest | Where-Object { $_ -ne '--force' })
+                    if ($Names.Count -ne 1) {
+                        _cp_die 'usage: claude-profile skills unregister [--force] <name>'
+                        return
+                    }
+                    $SkillName = $Names[0]
+                    if (-not (_cp_validate_skill_name $SkillName)) { return }
+                    $PoolEntry = Join-Path $PoolDir $SkillName
+                    $Item = Get-Item -LiteralPath $PoolEntry -Force -ErrorAction SilentlyContinue
+                    if (-not $Item) {
+                        _cp_die "skill '$SkillName' is not registered"
+                        return
+                    }
+                    if ($Item.LinkType) {
+                        if (-not (Remove-CPSkillLink -Path $PoolEntry)) {
+                            _cp_die "could not remove $PoolEntry"
+                            return
+                        }
+                    } else {
+                        if (-not $Force) {
+                            _cp_die "'$SkillName' is a real directory in the pool; pass --force to delete it and its contents"
+                            return
+                        }
+                        Remove-Item -LiteralPath $PoolEntry -Recurse -Force
+                    }
+                    foreach ($ProfileEntry in @(Get-ChildItem -Path $DataDir -Directory -ErrorAction SilentlyContinue |
+                        Where-Object { $_.Name -ne 'skills' })) {
+                        $Manifest = Join-Path $ProfileEntry.FullName 'skills.conf'
+                        if ((Test-Path -LiteralPath $Manifest -PathType Leaf) -and
+                            (@(Read-CPSkillManifest -Path $Manifest) -contains $SkillName)) {
+                            _cp_die "note: profile '$($ProfileEntry.Name)' still lists '$SkillName' in skills.conf"
+                        }
+                    }
+                    Write-Host "Unregistered skill: $SkillName"
+                    Write-Host "Run 'claude-profile skills sync --all' to remove stale links from profiles."
+                }
+
+                { $_ -eq 'add' -or $_ -eq 'remove' } {
+                    $Op = $Sub
+                    $SkillName = if ($args.Count -gt 2) { $args[2] } else { $null }
+                    $ProfileArg = if ($args.Count -gt 3) { $args[3] } else { $null }
+                    if (-not $SkillName) {
+                        _cp_die "usage: claude-profile skills $Op <skill> [profile]"
+                        return
+                    }
+                    if ($args.Count -gt 4) {
+                        _cp_die "unexpected argument '$($args[4])'"
+                        return
+                    }
+                    if (-not (_cp_validate_skill_name $SkillName)) { return }
+                    $ProfileName = _cp_skills_profile $ProfileArg
+                    if (-not $ProfileName) { return }
+                    if ($Op -eq 'add' -and
+                        -not (Test-Path -LiteralPath (Join-Path $PoolDir $SkillName) -PathType Container)) {
+                        _cp_die "skill '$SkillName' is not in the pool. Register it with: claude-profile skills register $SkillName <path>"
+                        return
+                    }
+                    $Manifest = Join-Path (Join-Path $DataDir $ProfileName) 'skills.conf'
+                    # Materialize the implicit "all pool skills" default first
+                    # so add/remove edits stay sticky.
+                    if (-not (Test-Path -LiteralPath $Manifest -PathType Leaf)) {
+                        $All = @(Get-CPPoolSkills -PoolDir $PoolDir)
+                        [System.IO.File]::WriteAllLines($Manifest, [string[]]$All)
+                    }
+                    $Current = @(Read-CPSkillManifest -Path $Manifest)
+                    if ($Op -eq 'add') {
+                        if ($Current -notcontains $SkillName) { $Current += $SkillName }
+                    } else {
+                        $Current = @($Current | Where-Object { $_ -ne $SkillName })
+                    }
+                    [System.IO.File]::WriteAllLines($Manifest, [string[]]$Current)
+                    if (-not (Sync-CPProfileSkills -Name $ProfileName)) { return }
+                    if ($Op -eq 'add') {
+                        Write-Host "Added skill '$SkillName' to profile '$ProfileName'"
+                    } else {
+                        Write-Host "Removed skill '$SkillName' from profile '$ProfileName'"
+                    }
+                }
+
+                'set' {
+                    $ListArg = if ($args.Count -gt 2) { $args[2] } else { $null }
+                    $ProfileArg = if ($args.Count -gt 3) { $args[3] } else { $null }
+                    if (-not $ListArg) {
+                        _cp_die 'usage: claude-profile skills set <skill1,skill2,...> [profile]'
+                        return
+                    }
+                    if ($args.Count -gt 4) {
+                        _cp_die "unexpected argument '$($args[4])'"
+                        return
+                    }
+                    $ProfileName = _cp_skills_profile $ProfileArg
+                    if (-not $ProfileName) { return }
+                    $Names = @()
+                    foreach ($SkillName in ($ListArg -split ',')) {
+                        if (-not $SkillName) { continue }
+                        if (-not (_cp_validate_skill_name $SkillName)) { return }
+                        if (-not (Test-Path -LiteralPath (Join-Path $PoolDir $SkillName) -PathType Container)) {
+                            _cp_die "warning: skill '$SkillName' is not in the pool"
+                        }
+                        $Names += $SkillName
+                    }
+                    $Manifest = Join-Path (Join-Path $DataDir $ProfileName) 'skills.conf'
+                    [System.IO.File]::WriteAllLines($Manifest, [string[]]$Names)
+                    if (-not (Sync-CPProfileSkills -Name $ProfileName)) { return }
+                    Write-Host "Set skills for profile '$ProfileName'"
+                }
+
+                'reset' {
+                    $ProfileArg = if ($args.Count -gt 2) { $args[2] } else { $null }
+                    if ($args.Count -gt 3) {
+                        _cp_die "unexpected argument '$($args[3])'"
+                        return
+                    }
+                    $ProfileName = _cp_skills_profile $ProfileArg
+                    if (-not $ProfileName) { return }
+                    Remove-Item -LiteralPath (Join-Path (Join-Path $DataDir $ProfileName) 'skills.conf') -Force -ErrorAction SilentlyContinue
+                    if (-not (Sync-CPProfileSkills -Name $ProfileName)) { return }
+                    Write-Host "Profile '$ProfileName' reset to all pool skills"
+                }
+
+                'sync' {
+                    $Target = if ($args.Count -gt 2) { $args[2] } else { $null }
+                    if ($args.Count -gt 3) {
+                        _cp_die "unexpected argument '$($args[3])'"
+                        return
+                    }
+                    if ($Target -eq '--all') {
+                        foreach ($ProfileEntry in @(Get-ChildItem -Path $DataDir -Directory -ErrorAction SilentlyContinue |
+                            Where-Object { $_.Name -ne 'skills' })) {
+                            Sync-CPProfileSkills -Name $ProfileEntry.Name | Out-Null
+                            Write-Host "Synced profile '$($ProfileEntry.Name)'"
+                        }
+                    } else {
+                        $ProfileName = _cp_skills_profile $Target
+                        if (-not $ProfileName) { return }
+                        if (-not (Sync-CPProfileSkills -Name $ProfileName)) { return }
+                        Write-Host "Synced profile '$ProfileName'"
+                    }
+                }
+
+                $null {
+                    if (-not (Test-Path -LiteralPath $PoolDir -PathType Container)) {
+                        Write-Host 'No skill pool yet. Register a skill with: claude-profile skills register <name> <path>'
+                        return
+                    }
+                    $ProfileName = _cp_skills_profile $null
+                    if (-not $ProfileName) { return }
+                    $ProfileDir = Join-Path $DataDir $ProfileName
+                    if (Test-Path -LiteralPath (Join-Path $ProfileDir 'skills.conf') -PathType Leaf) {
+                        Write-Host "Profile '$ProfileName': skills.conf present (filtered)"
+                    } else {
+                        Write-Host "Profile '$ProfileName': no skills.conf (all pool skills)"
+                    }
+                    Write-Host "Skill pool: $PoolDir"
+                    $Desired = @(Get-CPDesiredSkills -ProfileDir $ProfileDir -PoolDir $PoolDir)
+                    $Pool = @(Get-CPPoolSkills -PoolDir $PoolDir)
+                    if ($Pool.Count -eq 0) {
+                        Write-Host '  (pool is empty)'
+                        return
+                    }
+                    foreach ($SkillName in $Pool) {
+                        $PoolEntry = Join-Path $PoolDir $SkillName
+                        $Dest = Join-Path (Join-Path $ProfileDir 'skills') $SkillName
+                        $DestItem = Get-Item -LiteralPath $Dest -Force -ErrorAction SilentlyContinue
+                        $Status = 'not linked'
+                        if (-not (Test-Path -LiteralPath $PoolEntry -PathType Container)) {
+                            $Status = 'dangling (target missing)'
+                        } elseif ($DestItem) {
+                            if (Test-CPManagedSkillLink -Path $Dest -PoolDir $PoolDir) {
+                                $Status = 'linked'
+                            } else {
+                                $Status = 'conflict (unmanaged entry)'
+                            }
+                        } elseif ($Desired -contains $SkillName) {
+                            $Status = 'selected, not linked (run sync)'
+                        }
+                        Write-Host ("  {0,-24} {1}" -f $SkillName, $Status)
+                    }
+                }
+
+                default {
+                    _cp_die "unknown skills command '$Sub'. Run 'claude-profile help' for usage."
+                    return
+                }
+            }
+        }
+
         'version' {
             Write-Host (Get-CPInstalledVersion)
         }
@@ -791,6 +1255,20 @@ Commands:
                             directory-local profile for the current directory
     auto [on|off|status]    Control directory-local auto-switching
     which [name]            Show the resolved config directory path
+    skills                  List pool skills and their status for the profile
+    skills register <name> <path>
+                            Add a skill directory to the shared pool
+    skills unregister [--force] <name>
+                            Remove a skill from the pool
+    skills add <skill> [profile]
+                            Add a pool skill to a profile
+    skills remove <skill> [profile]
+                            Remove a pool skill from a profile
+    skills set <s1,s2,...> [profile]
+                            Replace a profile's skill selection
+    skills reset [profile]  Back to the default (all pool skills)
+    skills sync [profile|--all]
+                            Re-materialize skill links
     version                 Show the installed version
     update [--force]        Update to the latest release
     delete <name>           Delete a profile
@@ -806,8 +1284,15 @@ any .claude-profile until 'claude-profile auto on'. Set
 CLAUDE_PROFILE_NO_AUTO_SWITCH=1 to disable, CLAUDE_PROFILE_AUTO_QUIET=1
 to switch silently.
 
+Skills: a shared pool at <data-dir>\skills holds registered skills. A
+profile's skills.conf (one name per line, # comments) selects the subset
+linked into <profile>\skills; without one the profile gets every pool
+skill. Hand-made entries in <profile>\skills are never touched.
+
 Examples:
     claude-profile create work
+    claude-profile skills register humanize C:\skills\humanize
+    claude-profile skills set humanize,optimize work
     claude-profile default work
     claude-profile use work
     claude                          # runs with "work" profile
@@ -851,6 +1336,22 @@ Examples:
                 Write-Host "Default profile: $CurDefault"
             } else {
                 Write-Host 'No default profile set'
+            }
+            # Skills annotation for the active (else default) profile;
+            # silent until a skill pool exists.
+            $PoolDir = Join-Path $DataDir 'skills'
+            if (Test-Path -LiteralPath $PoolDir -PathType Container) {
+                $SkillProfile = if ($Active) { $Active } else { $CurDefault }
+                if ($SkillProfile -and (Test-Path (Join-Path $DataDir $SkillProfile) -PathType Container)) {
+                    $PoolCount = @(Get-CPPoolSkills -PoolDir $PoolDir).Count
+                    $Manifest = Join-Path (Join-Path $DataDir $SkillProfile) 'skills.conf'
+                    if (Test-Path -LiteralPath $Manifest -PathType Leaf) {
+                        $SkillCount = @(Read-CPSkillManifest -Path $Manifest).Count
+                        Write-Host "Skills: $SkillCount of $PoolCount pool skills (filtered)"
+                    } else {
+                        Write-Host "Skills: all pool skills ($PoolCount)"
+                    }
+                }
             }
         }
 

--- a/claude-profile-init.ps1
+++ b/claude-profile-init.ps1
@@ -389,18 +389,17 @@ function Get-CPLinkTarget {
 
 # Removes a link without touching its target. FileSystemInfo.Delete() is
 # non-recursive, so on a junction it removes only the reparse point.
+# Deliberately NO Remove-Item fallback: on Windows PowerShell 5.1,
+# Remove-Item on a junction follows the reparse point and deletes the
+# TARGET's contents (fixed only in PS 6.2+) — failing here must never
+# escalate into deleting the user's skill source.
 function Remove-CPSkillLink {
     param([string]$Path)
     try {
         (Get-Item -LiteralPath $Path -Force -ErrorAction Stop).Delete()
         return $true
     } catch {
-        try {
-            Remove-Item -LiteralPath $Path -Force -ErrorAction Stop
-            return $true
-        } catch {
-            return $false
-        }
+        return $false
     }
 }
 
@@ -412,7 +411,12 @@ function Test-CPManagedSkillLink {
     if (-not $target) { return $false }
     $normTarget = $target.Replace('\', '/').TrimEnd('/')
     $normPool = $PoolDir.Replace('\', '/').TrimEnd('/')
-    return $normTarget.StartsWith("$normPool/")
+    # Windows paths are case-insensitive; %LOCALAPPDATA% casing can differ
+    # between the shell that created a junction and this one.
+    if ($IsWindows -or ($PSVersionTable.PSEdition -eq 'Desktop')) {
+        return $normTarget.StartsWith("$normPool/", [System.StringComparison]::OrdinalIgnoreCase)
+    }
+    return $normTarget.StartsWith("$normPool/", [System.StringComparison]::Ordinal)
 }
 
 # Returns the valid skill names from manifest file $Path. Blank lines and
@@ -461,6 +465,21 @@ function Get-CPDesiredSkills {
     return @(Get-CPPoolSkills -PoolDir $PoolDir)
 }
 
+# Fails when <data>/skills exists but looks like a Claude Code profile —
+# i.e. a profile named 'skills' created before that name was reserved.
+# Without this, pool operations would enumerate its internals as skills
+# and link them into every profile.
+function Test-CPPoolGuard {
+    $poolDir = Join-Path (Get-CPDataDir) 'skills'
+    if (-not (Test-Path -LiteralPath $poolDir -PathType Container)) { return $true }
+    if ((Test-Path -LiteralPath (Join-Path $poolDir 'settings.json') -PathType Leaf) -or
+        (Test-Path -LiteralPath (Join-Path $poolDir '.credentials.json') -PathType Leaf)) {
+        $host.UI.WriteErrorLine("claude-profile: $poolDir looks like a Claude Code profile, not a skill pool (the name 'skills' is now reserved). Move that profile aside before using skill pools.")
+        return $false
+    }
+    return $true
+}
+
 # Re-materializes managed skill links for profile $Name from its manifest
 # (or the whole pool when no manifest).
 function Sync-CPProfileSkills {
@@ -469,6 +488,18 @@ function Sync-CPProfileSkills {
     $poolDir = Join-Path $dataDir 'skills'
     $profileDir = Join-Path $dataDir $Name
     $skillsDir = Join-Path $profileDir 'skills'
+    if (-not (Test-CPPoolGuard)) { return $false }
+    # A manifest that exists but can't be read must abort, not silently
+    # become "select nothing" and strip the profile's managed links.
+    $manifest = Join-Path $profileDir 'skills.conf'
+    if (Test-Path -LiteralPath $manifest -PathType Leaf) {
+        try {
+            [void](Get-Content -LiteralPath $manifest -ErrorAction Stop)
+        } catch {
+            $host.UI.WriteErrorLine("claude-profile: cannot read ${manifest}; not syncing")
+            return $false
+        }
+    }
     $desired = @(Get-CPDesiredSkills -ProfileDir $profileDir -PoolDir $poolDir)
     try {
         New-Item -ItemType Directory -Path $skillsDir -Force -ErrorAction Stop | Out-Null
@@ -933,6 +964,7 @@ function claude-profile {
 
         'skills' {
             $PoolDir = Join-Path $DataDir 'skills'
+            if (-not (Test-CPPoolGuard)) { return }
             $Sub = if ($args.Count -gt 1) { $args[1] } else { $null }
             switch ($Sub) {
                 'register' {

--- a/claude-profile.cmd
+++ b/claude-profile.cmd
@@ -1083,6 +1083,10 @@ echo Run 'claude-profile skills sync --all' to link it into unfiltered profiles.
 exit /b 0
 
 :cmd_skills_unregister
+if not "%~4"=="" (
+    echo claude-profile: unexpected argument '%~4' >&2
+    exit /b 1
+)
 set "_sk_force=0"
 set "_sk_name="
 if /i "%~2"=="--force" (

--- a/claude-profile.cmd
+++ b/claude-profile.cmd
@@ -499,12 +499,36 @@ if not exist "%DATA_DIR%\!_sp_name!\" (
 )
 exit /b 0
 
+:: pool_guard -> errorlevel 1 when %DATA_DIR%\skills exists but looks like
+:: a Claude Code profile (a profile named 'skills' created before that
+:: name was reserved). Without this, pool operations would enumerate its
+:: internals as skills and link them into every profile.
+:pool_guard
+if not exist "%DATA_DIR%\skills\" exit /b 0
+if exist "%DATA_DIR%\skills\settings.json" goto :pool_guard_fail
+if exist "%DATA_DIR%\skills\.credentials.json" goto :pool_guard_fail
+exit /b 0
+:pool_guard_fail
+echo claude-profile: %DATA_DIR%\skills looks like a Claude Code profile, not a skill pool ^(the name 'skills' is now reserved^). Move that profile aside before using skill pools. >&2
+exit /b 1
+
 :: sync_profile <name> -> re-materializes managed skill junctions for the
 :: profile from its manifest (or the whole pool when no manifest).
 :sync_profile
+call :pool_guard
+if errorlevel 1 exit /b 1
 set "_sy_pool=%DATA_DIR%\skills"
 set "_sy_pdir=%DATA_DIR%\%~1"
 set "_sy_sdir=!_sy_pdir!\skills"
+:: A manifest that exists but can't be read must abort, not silently
+:: become "select nothing" and strip the profile's managed links.
+if exist "!_sy_pdir!\skills.conf" (
+    type "!_sy_pdir!\skills.conf" >nul 2>&1
+    if errorlevel 1 (
+        echo claude-profile: cannot read !_sy_pdir!\skills.conf; not syncing >&2
+        exit /b 1
+    )
+)
 call :desired_skills "!_sy_pdir!"
 if not exist "!_sy_sdir!\" mkdir "!_sy_sdir!" >nul 2>&1
 if not exist "!_sy_sdir!\" (
@@ -1002,6 +1026,8 @@ exit /b 0
 
 :cmd_skills
 set "_sk_pool=%DATA_DIR%\skills"
+call :pool_guard
+if errorlevel 1 exit /b 1
 if "%~1"=="" goto :cmd_skills_list
 if /i "%~1"=="register"   goto :cmd_skills_register
 if /i "%~1"=="unregister" goto :cmd_skills_unregister
@@ -1081,21 +1107,18 @@ set "_vs_name=!_sk_name!"
 call :validate_skill_name
 if errorlevel 1 exit /b 1
 set "_sk_entry=!_sk_pool!\!_sk_name!"
-:: `if exist` resolves links, so a dangling junction reads as absent; the
-:: dir /AL scan still sees the entry itself and lets it be unregistered.
-set "_sk_present=0"
-if exist "!_sk_entry!" set "_sk_present=1"
-if exist "!_sk_entry!\" set "_sk_present=1"
-for /f "usebackq delims=" %%e in (`dir /AL /B "!_sk_pool!" 2^>nul ^| findstr /X /C:"!_sk_name!" 2^>nul`) do set "_sk_present=1"
-if "!_sk_present!"=="0" (
-    echo claude-profile: skill '!_sk_name!' is not registered >&2
-    exit /b 1
-)
-:: A bare rmdir removes a junction (or an empty real directory) without
-:: touching its target; a non-empty real directory survives it and needs
-:: an explicit --force to be deleted recursively.
-rmdir "!_sk_entry!" >nul 2>&1
-if exist "!_sk_entry!\" (
+:: Detect link-ness FIRST (never probe by deleting). `if exist` resolves
+:: links, so a dangling junction reads as absent — the dir /AL scan still
+:: sees the entry itself and lets it be unregistered.
+set "_sk_islink=0"
+for /f "usebackq delims=" %%e in (`dir /AL /B "!_sk_pool!" 2^>nul ^| findstr /X /C:"!_sk_name!" 2^>nul`) do set "_sk_islink=1"
+if "!_sk_islink!"=="1" (
+    rmdir "!_sk_entry!" >nul 2>&1
+    if exist "!_sk_entry!\" (
+        echo claude-profile: could not remove !_sk_entry! >&2
+        exit /b 1
+    )
+) else if exist "!_sk_entry!\" (
     if "!_sk_force!"=="0" (
         echo claude-profile: '!_sk_name!' is a real directory in the pool; pass --force to delete it and its contents >&2
         exit /b 1
@@ -1105,6 +1128,9 @@ if exist "!_sk_entry!\" (
         echo claude-profile: could not remove !_sk_entry! >&2
         exit /b 1
     )
+) else (
+    echo claude-profile: skill '!_sk_name!' is not registered >&2
+    exit /b 1
 )
 for /d %%d in ("%DATA_DIR%\*") do (
     if /i not "%%~nxd"=="skills" if exist "%%d\skills.conf" (
@@ -1182,6 +1208,12 @@ if not "%~4"=="" (
 call :skills_profile "%~3"
 if errorlevel 1 exit /b 1
 set "_sk_listarg=%~2"
+:: Reject anything but names and commas up front: a bare `for %%n in (...)`
+:: would otherwise glob-expand wildcards against the current directory.
+echo !_sk_listarg!| findstr /R "^[a-zA-Z0-9_,-][a-zA-Z0-9_,-]*$" >nul 2>&1 || (
+    echo claude-profile: invalid skill list '%~2': use comma-separated names ^(letters, digits, hyphens, underscores^) >&2
+    exit /b 1
+)
 set "_sk_manifest=%DATA_DIR%\!_sp_name!\skills.conf"
 set "_sk_tmp=!_sk_manifest!.tmp.%RANDOM%"
 set "_sk_bad=0"

--- a/claude-profile.cmd
+++ b/claude-profile.cmd
@@ -37,6 +37,7 @@ if "%~1"=="-h"      goto :usage
 if "%~1"=="--help"  goto :usage
 if "%~1"=="version" goto :dispatch_version
 if "%~1"=="update"  goto :dispatch_update
+if "%~1"=="skills"  goto :dispatch_skills
 
 :: Flags without a subcommand are not supported
 set "_first=%~1"
@@ -86,6 +87,10 @@ goto :cmd_version
 :dispatch_update
 shift
 goto :cmd_update
+
+:dispatch_skills
+shift
+goto :cmd_skills
 
 :get_epoch
 :: cmd has no native epoch-time support; PowerShell ships with every
@@ -285,6 +290,14 @@ echo     local [name]            Show, set (.claude-profile), or --remove the
 echo                             directory-local profile for this directory
 echo     delete ^<name^>           Delete a profile
 echo     which [name]            Show the resolved config directory path
+echo     skills                  List pool skills and their status for the profile
+echo     skills register ^<name^> ^<path^>   Add a skill directory to the shared pool
+echo     skills unregister [--force] ^<name^>   Remove a skill from the pool
+echo     skills add ^<skill^> [profile]     Add a pool skill to a profile
+echo     skills remove ^<skill^> [profile]  Remove a pool skill from a profile
+echo     skills set ^<s1,s2,...^> [profile] Replace a profile's skill selection
+echo     skills reset [profile]           Back to the default (all pool skills^)
+echo     skills sync [profile^|--all]      Re-materialize skill links
 echo     version                 Show the installed version
 echo     update [--force]        Update to the latest release
 echo     help, -h, --help        Show this help message
@@ -296,6 +309,11 @@ echo A directory containing a .claude-profile file (holding a profile name)
 echo is preferred over the default profile by a bare 'call claude-profile'.
 echo cmd.exe has no cd hook, so this resolves at invocation time rather than
 echo automatically on cd as it does in the sh and PowerShell versions.
+echo.
+echo Skills: a shared pool at %%LOCALAPPDATA%%\claude-profiles\skills holds
+echo registered skills. A profile's skills.conf (one name per line, # comments^)
+echo selects the subset linked into ^<profile^>\skills; without one the profile
+echo gets every pool skill. Hand-made entries are never touched.
 echo.
 echo Examples:
 echo     claude-profile create work
@@ -341,7 +359,188 @@ echo !_vn_name!| findstr /R "^[a-zA-Z0-9_-][a-zA-Z0-9_-]*$" >nul 2>&1 || (
     exit /b 1
 )
 
+:: 'skills' is the skill pool directory inside the data dir
+if /i "!_vn_name!"=="skills" (
+    echo claude-profile: profile name 'skills' is reserved for the skill pool >&2
+    exit /b 1
+)
+
 goto :eof
+
+:: --- Skill pool helpers ---
+::
+:: A central pool at %DATA_DIR%\skills holds registered skills (directories
+:: or junctions to skill source directories). Each profile may carry a
+:: skills.conf manifest (one pool-skill name per line, # comments) naming
+:: the subset it wants; no manifest means every pool skill. Sync
+:: materializes the selection as junctions in <profile>\skills. Only
+:: junctions pointing at the pool are ever created or removed -- hand-made
+:: links, real directories, and files are left alone.
+
+:: validate_skill_name -- expects the name in %_vs_name%, errorlevel 1 on failure
+:validate_skill_name
+if "%_vs_name%"=="" (
+    echo claude-profile: skill name must not be empty >&2
+    exit /b 1
+)
+echo !_vs_name!| findstr /R "^[a-zA-Z0-9_-][a-zA-Z0-9_-]*$" >nul 2>&1 || (
+    echo claude-profile: invalid skill name '%_vs_name%': use only letters, digits, hyphens, underscores >&2
+    exit /b 1
+)
+goto :eof
+
+:: get_link_target <parent-dir> <entry-name> -> sets _lt_target to the link
+:: target shown by `dir /AL` (empty when the entry is not a link). Names are
+:: validated (no spaces or brackets), so " name [" is an exact-entry match.
+:get_link_target
+set "_lt_target="
+for /f "usebackq tokens=*" %%L in (`dir /AL "%~1" 2^>nul ^| findstr /C:" %~2 [" 2^>nul`) do (
+    set "_lt_line=%%L"
+    set "_lt_target=!_lt_line:*[=!"
+    if "!_lt_target:~-1!"=="]" set "_lt_target=!_lt_target:~0,-1!"
+)
+goto :eof
+
+:: read_manifest <path> -> sets _mf_list to a space-delimited list of the
+:: valid skill names (with leading/trailing spaces for membership tests).
+:: Blank lines and # comments are skipped; invalid names warn and are
+:: skipped so one bad line never fails a whole sync.
+:read_manifest
+call :capture_cr
+set "_mf_list= "
+if not exist "%~1" goto :eof
+for /f "usebackq eol=# tokens=* delims=	 " %%L in ("%~1") do (
+    set "_mf_line=%%L"
+    call :trim_manifest_line
+    if defined _mf_line (
+        echo !_mf_line!| findstr /R "^[a-zA-Z0-9_-][a-zA-Z0-9_-]*$" >nul 2>&1
+        if not errorlevel 1 (
+            set "_mf_list=!_mf_list!!_mf_line! "
+        ) else (
+            echo claude-profile: skills.conf: ignoring invalid skill name '!_mf_line!' >&2
+        )
+    )
+)
+goto :eof
+
+:: count_manifest -> sets _mf_count to the number of names in _mf_list.
+:count_manifest
+set "_mf_count=0"
+for %%n in (!_mf_list!) do set /a _mf_count+=1
+goto :eof
+
+:trim_manifest_line
+if not defined _mf_line goto :eof
+if "!_mf_line:~-1!"==" "       (set "_mf_line=!_mf_line:~0,-1!" & goto :trim_manifest_line)
+if "!_mf_line:~-1!"=="	"      (set "_mf_line=!_mf_line:~0,-1!" & goto :trim_manifest_line)
+if "!_mf_line:~-1!"=="!_CP_CR!" (set "_mf_line=!_mf_line:~0,-1!" & goto :trim_manifest_line)
+goto :eof
+
+:: pool_skills -> sets _pl_list to a space-delimited list of every skill
+:: registered in the pool (junctions enumerate like directories, dangling
+:: ones included) and _pl_count to how many there are.
+:pool_skills
+set "_pl_list= "
+set "_pl_count=0"
+if not exist "%DATA_DIR%\skills\" goto :eof
+for /d %%d in ("%DATA_DIR%\skills\*") do (
+    set "_pl_list=!_pl_list!%%~nxd "
+    set /a _pl_count+=1
+)
+goto :eof
+
+:: desired_skills <profile-dir> -> sets _ds_list to the space-delimited
+:: desired skill set: the manifest names when skills.conf exists, every
+:: pool skill otherwise.
+:desired_skills
+if exist "%~1\skills.conf" (
+    call :read_manifest "%~1\skills.conf"
+    set "_ds_list=!_mf_list!"
+) else (
+    call :pool_skills
+    set "_ds_list=!_pl_list!"
+)
+goto :eof
+
+:: skills_profile <name-or-empty> -> sets _sp_name to the profile a skills
+:: command acts on: the explicit argument if given, else the active profile
+:: (CLAUDE_CONFIG_DIR under DATA_DIR), else the default. errorlevel 1 on failure.
+:skills_profile
+set "_sp_name="
+if not "%~1"=="" (
+    set "_vn_name=%~1"
+    call :validate_name
+    if errorlevel 1 exit /b 1
+    set "_sp_name=%~1"
+    goto :skills_profile_check
+)
+if defined CLAUDE_CONFIG_DIR (
+    for %%p in ("!CLAUDE_CONFIG_DIR!") do set "_sp_cand=%%~nxp"
+    if /i "!CLAUDE_CONFIG_DIR!"=="%DATA_DIR%\!_sp_cand!" (
+        set "_sp_name=!_sp_cand!"
+        goto :skills_profile_check
+    )
+    echo claude-profile: active CLAUDE_CONFIG_DIR is not a managed profile; pass a profile name >&2
+    exit /b 1
+)
+if not exist "%DEFAULT_FILE%" (
+    echo claude-profile: no profile specified and no default profile set >&2
+    exit /b 1
+)
+set /p _sp_name=<"%DEFAULT_FILE%"
+if "!_sp_name!"=="" (
+    echo claude-profile: no profile specified and no default profile set >&2
+    exit /b 1
+)
+:skills_profile_check
+if not exist "%DATA_DIR%\!_sp_name!\" (
+    echo claude-profile: profile '!_sp_name!' does not exist >&2
+    exit /b 1
+)
+exit /b 0
+
+:: sync_profile <name> -> re-materializes managed skill junctions for the
+:: profile from its manifest (or the whole pool when no manifest).
+:sync_profile
+set "_sy_pool=%DATA_DIR%\skills"
+set "_sy_pdir=%DATA_DIR%\%~1"
+set "_sy_sdir=!_sy_pdir!\skills"
+call :desired_skills "!_sy_pdir!"
+if not exist "!_sy_sdir!\" mkdir "!_sy_sdir!" >nul 2>&1
+if not exist "!_sy_sdir!\" (
+    echo claude-profile: cannot create !_sy_sdir! >&2
+    exit /b 1
+)
+
+:: Pass 1: drop managed junctions that are dangling or no longer desired.
+for /f "usebackq delims=" %%e in (`dir /AL /B "!_sy_sdir!" 2^>nul`) do (
+    call :get_link_target "!_sy_sdir!" "%%e"
+    if /i "!_lt_target!"=="!_sy_pool!\%%e" (
+        set "_sy_keep=1"
+        if "!_ds_list: %%e =!"=="!_ds_list!" set "_sy_keep=0"
+        if not exist "!_sy_pool!\%%e\" set "_sy_keep=0"
+        if "!_sy_keep!"=="0" (
+            rmdir "!_sy_sdir!\%%e" >nul 2>&1
+            if exist "!_sy_sdir!\%%e" echo claude-profile: could not remove !_sy_sdir!\%%e >&2
+        )
+    )
+)
+
+:: Pass 2: create junctions missing from the desired set.
+for %%n in (!_ds_list!) do (
+    if not exist "!_sy_pool!\%%n\" (
+        echo claude-profile: skill '%%n' is not in the pool ^(or its source is gone^); skipping >&2
+    ) else if exist "!_sy_sdir!\%%n" (
+        call :get_link_target "!_sy_sdir!" "%%n"
+        if /i not "!_lt_target!"=="!_sy_pool!\%%n" (
+            echo claude-profile: skill '%%n': unmanaged entry already at !_sy_sdir!\%%n; skipping >&2
+        )
+    ) else (
+        mklink /J "!_sy_sdir!\%%n" "!_sy_pool!\%%n" >nul 2>&1
+        if not exist "!_sy_sdir!\%%n" echo claude-profile: could not link skill '%%n' >&2
+    )
+)
+exit /b 0
 
 :: --- Directory-local profile (.claude-profile) ---
 ::
@@ -496,6 +695,10 @@ if exist "%_cc_dir%\" (
 mkdir "%_cc_dir%"
 echo Created profile: %~1
 echo Config directory: %_cc_dir%
+:: A new profile has no manifest, so this links every pool skill (the
+:: backward-compatible "all" default). No pool: no-op.
+set "_sk_pool=%DATA_DIR%\skills"
+if exist "%DATA_DIR%\skills\" call :sync_profile "%~1"
 exit /b 0
 
 :cmd_list
@@ -509,14 +712,23 @@ if exist "%DEFAULT_FILE%" (
     set /p _cl_default=<"%DEFAULT_FILE%"
 )
 
+call :pool_skills
 set "_cl_found=0"
 for /d %%d in ("%DATA_DIR%\*") do (
-    set "_cl_found=1"
-    set "_cl_name=%%~nxd"
-    if "!_cl_name!"=="!_cl_default!" (
-        echo * !_cl_name! (default^)
-    ) else (
-        echo   !_cl_name!
+    if /i not "%%~nxd"=="skills" (
+        set "_cl_found=1"
+        set "_cl_name=%%~nxd"
+        set "_cl_note="
+        if exist "%%d\skills.conf" (
+            call :read_manifest "%%d\skills.conf"
+            call :count_manifest
+            set "_cl_note= [skills: !_mf_count!/!_pl_count!]"
+        )
+        if "!_cl_name!"=="!_cl_default!" (
+            echo * !_cl_name! (default^)!_cl_note!
+        ) else (
+            echo   !_cl_name!!_cl_note!
+        )
     )
 )
 
@@ -786,6 +998,285 @@ if exist "%DEFAULT_FILE%" (
         echo Cleared default profile (was "!_cdel_name!"^)
     )
 )
+exit /b 0
+
+:cmd_skills
+set "_sk_pool=%DATA_DIR%\skills"
+if "%~1"=="" goto :cmd_skills_list
+if /i "%~1"=="register"   goto :cmd_skills_register
+if /i "%~1"=="unregister" goto :cmd_skills_unregister
+if /i "%~1"=="add"        goto :cmd_skills_addremove
+if /i "%~1"=="remove"     goto :cmd_skills_addremove
+if /i "%~1"=="set"        goto :cmd_skills_set
+if /i "%~1"=="reset"      goto :cmd_skills_reset
+if /i "%~1"=="sync"       goto :cmd_skills_sync
+echo claude-profile: unknown skills command '%~1'. Run 'claude-profile help' for usage. >&2
+exit /b 1
+
+:cmd_skills_register
+if "%~2"=="" (
+    echo claude-profile: usage: claude-profile skills register ^<name^> ^<path^> >&2
+    exit /b 1
+)
+if "%~3"=="" (
+    echo claude-profile: usage: claude-profile skills register ^<name^> ^<path^> >&2
+    exit /b 1
+)
+if not "%~4"=="" (
+    echo claude-profile: unexpected argument '%~4' >&2
+    exit /b 1
+)
+set "_vs_name=%~2"
+call :validate_skill_name
+if errorlevel 1 exit /b 1
+if not exist "%~3\" (
+    echo claude-profile: '%~3' is not a directory >&2
+    exit /b 1
+)
+if not exist "%~3\SKILL.md" (
+    echo claude-profile: '%~3' does not contain a SKILL.md >&2
+    exit /b 1
+)
+if not exist "!_sk_pool!\" mkdir "!_sk_pool!" >nul 2>&1
+if not exist "!_sk_pool!\" (
+    echo claude-profile: cannot create !_sk_pool! >&2
+    exit /b 1
+)
+if exist "!_sk_pool!\%~2" (
+    echo claude-profile: skill '%~2' is already registered >&2
+    exit /b 1
+)
+set "_sk_abs=%~f3"
+mklink /J "!_sk_pool!\%~2" "!_sk_abs!" >nul 2>&1
+if not exist "!_sk_pool!\%~2\" (
+    echo claude-profile: could not create pool link for '%~2' >&2
+    exit /b 1
+)
+echo Registered skill: %~2 -^> !_sk_abs!
+echo Run 'claude-profile skills sync --all' to link it into unfiltered profiles.
+exit /b 0
+
+:cmd_skills_unregister
+set "_sk_force=0"
+set "_sk_name="
+if /i "%~2"=="--force" (
+    set "_sk_force=1"
+) else if not "%~2"=="" (
+    set "_sk_name=%~2"
+)
+if /i "%~3"=="--force" (
+    set "_sk_force=1"
+) else if not "%~3"=="" (
+    if defined _sk_name (
+        echo claude-profile: unexpected argument '%~3' >&2
+        exit /b 1
+    )
+    set "_sk_name=%~3"
+)
+if not defined _sk_name (
+    echo claude-profile: usage: claude-profile skills unregister [--force] ^<name^> >&2
+    exit /b 1
+)
+set "_vs_name=!_sk_name!"
+call :validate_skill_name
+if errorlevel 1 exit /b 1
+set "_sk_entry=!_sk_pool!\!_sk_name!"
+:: `if exist` resolves links, so a dangling junction reads as absent; the
+:: dir /AL scan still sees the entry itself and lets it be unregistered.
+set "_sk_present=0"
+if exist "!_sk_entry!" set "_sk_present=1"
+if exist "!_sk_entry!\" set "_sk_present=1"
+for /f "usebackq delims=" %%e in (`dir /AL /B "!_sk_pool!" 2^>nul ^| findstr /X /C:"!_sk_name!" 2^>nul`) do set "_sk_present=1"
+if "!_sk_present!"=="0" (
+    echo claude-profile: skill '!_sk_name!' is not registered >&2
+    exit /b 1
+)
+:: A bare rmdir removes a junction (or an empty real directory) without
+:: touching its target; a non-empty real directory survives it and needs
+:: an explicit --force to be deleted recursively.
+rmdir "!_sk_entry!" >nul 2>&1
+if exist "!_sk_entry!\" (
+    if "!_sk_force!"=="0" (
+        echo claude-profile: '!_sk_name!' is a real directory in the pool; pass --force to delete it and its contents >&2
+        exit /b 1
+    )
+    rmdir /s /q "!_sk_entry!" >nul 2>&1
+    if exist "!_sk_entry!\" (
+        echo claude-profile: could not remove !_sk_entry! >&2
+        exit /b 1
+    )
+)
+for /d %%d in ("%DATA_DIR%\*") do (
+    if /i not "%%~nxd"=="skills" if exist "%%d\skills.conf" (
+        call :read_manifest "%%d\skills.conf"
+        call :warn_manifest_reference "%%~nxd"
+    )
+)
+echo Unregistered skill: !_sk_name!
+echo Run 'claude-profile skills sync --all' to remove stale links from profiles.
+exit /b 0
+
+:: warn_manifest_reference <profile-name> -- warns when the manifest just
+:: read into _mf_list still lists !_sk_name!. Split out of the loop above
+:: because nested delayed expansions of _sk_name inside a for block don't
+:: compose with the substring-membership test.
+:warn_manifest_reference
+if "!_mf_list: %_sk_name% =!"=="!_mf_list!" goto :eof
+echo claude-profile: note: profile '%~1' still lists '!_sk_name!' in skills.conf >&2
+goto :eof
+
+:cmd_skills_addremove
+set "_sk_op=%~1"
+if "%~2"=="" (
+    echo claude-profile: usage: claude-profile skills %_sk_op% ^<skill^> [profile] >&2
+    exit /b 1
+)
+if not "%~4"=="" (
+    echo claude-profile: unexpected argument '%~4' >&2
+    exit /b 1
+)
+set "_vs_name=%~2"
+call :validate_skill_name
+if errorlevel 1 exit /b 1
+call :skills_profile "%~3"
+if errorlevel 1 exit /b 1
+set "_sk_pdir=%DATA_DIR%\!_sp_name!"
+set "_sk_manifest=!_sk_pdir!\skills.conf"
+if /i "!_sk_op!"=="add" if not exist "!_sk_pool!\%~2\" (
+    echo claude-profile: skill '%~2' is not in the pool. Register it with: claude-profile skills register %~2 ^<path^> >&2
+    exit /b 1
+)
+:: Materialize the implicit "all pool skills" default first so add/remove
+:: edits stay sticky.
+if not exist "!_sk_manifest!" (
+    call :pool_skills
+    >"!_sk_manifest!" type nul
+    for %%n in (!_pl_list!) do >>"!_sk_manifest!" echo %%n
+)
+if /i "!_sk_op!"=="add" (
+    findstr /X /C:"%~2" "!_sk_manifest!" >nul 2>&1
+    if errorlevel 1 >>"!_sk_manifest!" echo %~2
+) else (
+    set "_sk_tmp=!_sk_manifest!.tmp.%RANDOM%"
+    findstr /V /X /C:"%~2" "!_sk_manifest!" >"!_sk_tmp!" 2>nul
+    move /y "!_sk_tmp!" "!_sk_manifest!" >nul 2>&1
+)
+call :sync_profile "!_sp_name!"
+if errorlevel 1 exit /b 1
+if /i "!_sk_op!"=="add" (
+    echo Added skill '%~2' to profile '!_sp_name!'
+) else (
+    echo Removed skill '%~2' from profile '!_sp_name!'
+)
+exit /b 0
+
+:cmd_skills_set
+if "%~2"=="" (
+    echo claude-profile: usage: claude-profile skills set ^<skill1,skill2,...^> [profile] >&2
+    exit /b 1
+)
+if not "%~4"=="" (
+    echo claude-profile: unexpected argument '%~4' >&2
+    exit /b 1
+)
+call :skills_profile "%~3"
+if errorlevel 1 exit /b 1
+set "_sk_listarg=%~2"
+set "_sk_manifest=%DATA_DIR%\!_sp_name!\skills.conf"
+set "_sk_tmp=!_sk_manifest!.tmp.%RANDOM%"
+set "_sk_bad=0"
+>"!_sk_tmp!" type nul
+:: cmd's for treats commas as delimiters, so the comma list splits natively.
+for %%n in (!_sk_listarg!) do (
+    set "_vs_name=%%n"
+    call :validate_skill_name
+    if errorlevel 1 (
+        set "_sk_bad=1"
+    ) else (
+        if not exist "!_sk_pool!\%%n\" (
+            echo claude-profile: warning: skill '%%n' is not in the pool >&2
+        )
+        >>"!_sk_tmp!" echo %%n
+    )
+)
+if "!_sk_bad!"=="1" (
+    del /f /q "!_sk_tmp!" >nul 2>&1
+    exit /b 1
+)
+move /y "!_sk_tmp!" "!_sk_manifest!" >nul 2>&1
+call :sync_profile "!_sp_name!"
+if errorlevel 1 exit /b 1
+echo Set skills for profile '!_sp_name!'
+exit /b 0
+
+:cmd_skills_reset
+if not "%~3"=="" (
+    echo claude-profile: unexpected argument '%~3' >&2
+    exit /b 1
+)
+call :skills_profile "%~2"
+if errorlevel 1 exit /b 1
+del /f /q "%DATA_DIR%\!_sp_name!\skills.conf" >nul 2>&1
+call :sync_profile "!_sp_name!"
+if errorlevel 1 exit /b 1
+echo Profile '!_sp_name!' reset to all pool skills
+exit /b 0
+
+:cmd_skills_sync
+if not "%~3"=="" (
+    echo claude-profile: unexpected argument '%~3' >&2
+    exit /b 1
+)
+if /i "%~2"=="--all" (
+    for /d %%d in ("%DATA_DIR%\*") do (
+        if /i not "%%~nxd"=="skills" (
+            call :sync_profile "%%~nxd"
+            echo Synced profile '%%~nxd'
+        )
+    )
+    exit /b 0
+)
+call :skills_profile "%~2"
+if errorlevel 1 exit /b 1
+call :sync_profile "!_sp_name!"
+if errorlevel 1 exit /b 1
+echo Synced profile '!_sp_name!'
+exit /b 0
+
+:cmd_skills_list
+if not exist "!_sk_pool!\" (
+    echo No skill pool yet. Register a skill with: claude-profile skills register ^<name^> ^<path^>
+    exit /b 0
+)
+call :skills_profile ""
+if errorlevel 1 exit /b 1
+set "_sk_pdir=%DATA_DIR%\!_sp_name!"
+if exist "!_sk_pdir!\skills.conf" (
+    echo Profile '!_sp_name!': skills.conf present ^(filtered^)
+) else (
+    echo Profile '!_sp_name!': no skills.conf ^(all pool skills^)
+)
+echo Skill pool: !_sk_pool!
+call :desired_skills "!_sk_pdir!"
+set "_sk_found=0"
+for /d %%d in ("!_sk_pool!\*") do (
+    set "_sk_found=1"
+    set "_sk_status=not linked"
+    if not exist "!_sk_pool!\%%~nxd\" (
+        set "_sk_status=dangling (target missing)"
+    ) else if exist "!_sk_pdir!\skills\%%~nxd" (
+        call :get_link_target "!_sk_pdir!\skills" "%%~nxd"
+        if /i "!_lt_target!"=="!_sk_pool!\%%~nxd" (
+            set "_sk_status=linked"
+        ) else (
+            set "_sk_status=conflict (unmanaged entry)"
+        )
+    ) else (
+        if not "!_ds_list: %%~nxd =!"=="!_ds_list!" set "_sk_status=selected, not linked (run sync)"
+    )
+    echo   %%~nxd	!_sk_status!
+)
+if "!_sk_found!"=="0" echo   (pool is empty)
 exit /b 0
 
 :cmd_launch_default

--- a/claude-profile.sh
+++ b/claude-profile.sh
@@ -66,7 +66,9 @@ _cp_validate_name() {
             _cp_die "invalid profile name '$1': use only letters, digits, hyphens, underscores"
             return 1
             ;;
-        skills)
+        [Ss][Kk][Ii][Ll][Ll][Ss])
+            # Case-insensitive: on Windows filesystems (Git Bash) 'SKILLS'
+            # resolves to the same directory as the pool.
             _cp_die "profile name 'skills' is reserved for the skill pool"
             return 1
             ;;
@@ -205,6 +207,20 @@ _cp_skills_materialize_manifest() {
     _cp_pool_skills "${_cp_data}/skills" > "$1/skills.conf"
 }
 
+# Fails when <data>/skills exists but looks like a Claude Code profile —
+# i.e. a profile named 'skills' created before that name was reserved.
+# Without this, pool operations would enumerate its internals as skills
+# and link them into every profile.
+_cp_pool_guard() {
+    _cp_pg_pool="${_cp_data}/skills"
+    [ -d "$_cp_pg_pool" ] || return 0
+    if [ -f "${_cp_pg_pool}/settings.json" ] || [ -f "${_cp_pg_pool}/.credentials.json" ]; then
+        _cp_die "${_cp_pg_pool} looks like a Claude Code profile, not a skill pool (the name 'skills' is now reserved). Move that profile aside before using skill pools."
+        return 1
+    fi
+    return 0
+}
+
 # Re-materializes managed skill links for profile NAME ($1) from its
 # manifest (or the whole pool when no manifest). Uses $_cp_data.
 _cp_skills_sync_one() {
@@ -212,6 +228,13 @@ _cp_skills_sync_one() {
     _cp_ss_pool="${_cp_data}/skills"
     _cp_ss_pdir="${_cp_data}/${_cp_ss_name}"
     _cp_ss_sdir="${_cp_ss_pdir}/skills"
+    _cp_pool_guard || return 1
+    # A manifest that exists but can't be read must abort, not silently
+    # become "select nothing" and strip the profile's managed links.
+    if [ -f "${_cp_ss_pdir}/skills.conf" ] && [ ! -r "${_cp_ss_pdir}/skills.conf" ]; then
+        _cp_die "cannot read ${_cp_ss_pdir}/skills.conf; not syncing"
+        return 1
+    fi
     _cp_ss_desired=$(_cp_desired_skills "$_cp_ss_pdir" "$_cp_ss_pool")
     mkdir -p "$_cp_ss_sdir" 2>/dev/null || { _cp_die "cannot create ${_cp_ss_sdir}"; return 1; }
 
@@ -730,7 +753,7 @@ _cp_auto_switch() {
     fi
 
     case "$_cp_dotname" in
-        skills|.*|*..*|*/*|*\\*|*[!A-Za-z0-9_-]*)
+        [Ss][Kk][Ii][Ll][Ll][Ss]|.*|*..*|*/*|*\\*|*[!A-Za-z0-9_-]*)
             _cp_die "ignoring ${_cp_dotfile}: invalid profile name '${_cp_dotname}'"
             return 1
             ;;
@@ -1177,6 +1200,7 @@ SETTINGSEOF
         skills)
             shift
             _cp_sk_pool="${_cp_data}/skills"
+            _cp_pool_guard || return 1
             case "${1:-}" in
                 register)
                     shift
@@ -1261,8 +1285,11 @@ SETTINGSEOF
                         _cp_sk_pn="${_cp_sk_p%/}"
                         _cp_sk_pn="${_cp_sk_pn##*/}"
                         [ "$_cp_sk_pn" = "skills" ] && continue
+                        # Read via _cp_read_manifest so CRLF manifests
+                        # written by the cmd/PowerShell implementations
+                        # still match.
                         if [ -f "${_cp_sk_p%/}/skills.conf" ] \
-                            && grep -qx "$_cp_sk_name" "${_cp_sk_p%/}/skills.conf" 2>/dev/null; then
+                            && _cp_read_manifest "${_cp_sk_p%/}/skills.conf" 2>/dev/null | grep -Fqx "$_cp_sk_name"; then
                             _cp_die "note: profile '${_cp_sk_pn}' still lists '${_cp_sk_name}' in skills.conf"
                         fi
                     done
@@ -1291,14 +1318,23 @@ SETTINGSEOF
                     fi
                     _cp_skills_materialize_manifest "$_cp_sk_pdir" || { _cp_die "could not write skills.conf"; return 1; }
                     _cp_sk_file="${_cp_sk_pdir}/skills.conf"
+                    # Membership and removal go through CR/whitespace
+                    # trimming (not bare grep -x) so CRLF manifests written
+                    # by the cmd/PowerShell implementations still match.
                     if [ "$_cp_sk_op" = "add" ]; then
-                        if ! grep -qx "$_cp_sk_name" "$_cp_sk_file" 2>/dev/null; then
+                        if ! _cp_read_manifest "$_cp_sk_file" 2>/dev/null | grep -Fqx "$_cp_sk_name"; then
                             printf '%s\n' "$_cp_sk_name" >> "$_cp_sk_file" || return 1
                         fi
                         _cp_skills_sync_one "$_cp_sp_name" || return 1
                         printf "Added skill '%s' to profile '%s'\n" "$_cp_sk_name" "$_cp_sp_name"
                     else
-                        grep -vx "$_cp_sk_name" "$_cp_sk_file" > "${_cp_sk_file}.tmp.$$" 2>/dev/null
+                        awk -v n="$_cp_sk_name" '{
+                            l = $0
+                            sub(/\r$/, "", l)
+                            gsub(/^[ \t]+/, "", l); gsub(/[ \t]+$/, "", l)
+                            if (l == n) next
+                            print
+                        }' "$_cp_sk_file" > "${_cp_sk_file}.tmp.$$" 2>/dev/null
                         mv -f "${_cp_sk_file}.tmp.$$" "$_cp_sk_file" || { rm -f "${_cp_sk_file}.tmp.$$"; return 1; }
                         _cp_skills_sync_one "$_cp_sp_name" || return 1
                         printf "Removed skill '%s' from profile '%s'\n" "$_cp_sk_name" "$_cp_sp_name"

--- a/claude-profile.sh
+++ b/claude-profile.sh
@@ -38,34 +38,42 @@ _cp_data_dir() {
     printf '%s\n' "${XDG_DATA_HOME:-${HOME}/.local/share}/claude-profiles"
 }
 
-_cp_validate_name() {
+# Shared name validation for profiles and skills; $2 is the noun used in
+# error messages so both validators stay rule-identical by construction.
+_cp_validate_name_core() {
     case "$1" in
         "")
-            _cp_die "profile name must not be empty"
+            _cp_die "$2 name must not be empty"
             return 1
             ;;
         .*)
-            _cp_die "invalid profile name '$1': must not start with '.'"
+            _cp_die "invalid $2 name '$1': must not start with '.'"
             return 1
             ;;
         *..*)
-            _cp_die "invalid profile name '$1': must not contain '..'"
+            _cp_die "invalid $2 name '$1': must not contain '..'"
             return 1
             ;;
         */*)
-            _cp_die "invalid profile name '$1': must not contain '/'"
+            _cp_die "invalid $2 name '$1': must not contain '/'"
             return 1
             ;;
         *\\*)
-            _cp_die "invalid profile name '$1': must not contain '\\'"
+            _cp_die "invalid $2 name '$1': must not contain '\\'"
             return 1
             ;;
     esac
     case "$1" in
         *[!A-Za-z0-9_-]*)
-            _cp_die "invalid profile name '$1': use only letters, digits, hyphens, underscores"
+            _cp_die "invalid $2 name '$1': use only letters, digits, hyphens, underscores"
             return 1
             ;;
+    esac
+}
+
+_cp_validate_name() {
+    _cp_validate_name_core "$1" profile || return 1
+    case "$1" in
         [Ss][Kk][Ii][Ll][Ll][Ss])
             # Case-insensitive: on Windows filesystems (Git Bash) 'SKILLS'
             # resolves to the same directory as the pool.
@@ -86,34 +94,26 @@ _cp_validate_name() {
 # links, real directories, and files are left alone.
 
 _cp_validate_skill_name() {
-    case "$1" in
-        "")
-            _cp_die "skill name must not be empty"
-            return 1
-            ;;
-        .*)
-            _cp_die "invalid skill name '$1': must not start with '.'"
-            return 1
-            ;;
-        *..*)
-            _cp_die "invalid skill name '$1': must not contain '..'"
-            return 1
-            ;;
-        */*)
-            _cp_die "invalid skill name '$1': must not contain '/'"
-            return 1
-            ;;
-        *\\*)
-            _cp_die "invalid skill name '$1': must not contain '\\'"
-            return 1
-            ;;
+    _cp_validate_name_core "$1" skill
+}
+
+# Returns 0 when link target $1 lies under pool directory $2. Case-folds
+# on MSYS because the shared Windows data directory is case-insensitive
+# and %LOCALAPPDATA% casing can differ between the shell that created a
+# junction and this one (matches the cmd `if /i` and ps1
+# OrdinalIgnoreCase behavior).
+_cp_target_in_pool() {
+    if _cp_is_msys; then
+        _cp_tip_t=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+        _cp_tip_p=$(printf '%s' "$2" | tr '[:upper:]' '[:lower:]')
+    else
+        _cp_tip_t="$1"
+        _cp_tip_p="$2"
+    fi
+    case "$_cp_tip_t" in
+        "$_cp_tip_p"/*) return 0 ;;
     esac
-    case "$1" in
-        *[!A-Za-z0-9_-]*)
-            _cp_die "invalid skill name '$1': use only letters, digits, hyphens, underscores"
-            return 1
-            ;;
-    esac
+    return 1
 }
 
 # Prints the literal target of link $1 (fails if not a link). On MSYS the
@@ -241,13 +241,9 @@ _cp_skills_sync_one() {
     # Pass 1: drop managed links that are dangling or no longer desired.
     # The ls guard keeps zsh's nomatch from aborting on an empty glob.
     [ -n "$(ls "$_cp_ss_sdir" 2>/dev/null)" ] && for _cp_ss_e in "$_cp_ss_sdir"/*; do
-        [ -e "$_cp_ss_e" ] || [ -L "$_cp_ss_e" ] || continue
         [ -L "$_cp_ss_e" ] || continue
         _cp_ss_t=$(_cp_link_target "$_cp_ss_e") || continue
-        case "$_cp_ss_t" in
-            "$_cp_ss_pool"/*) ;;
-            *) continue ;;
-        esac
+        _cp_target_in_pool "$_cp_ss_t" "$_cp_ss_pool" || continue
         _cp_ss_b="${_cp_ss_e##*/}"
         if [ ! -d "${_cp_ss_pool}/${_cp_ss_b}" ] \
             || ! printf '%s\n' "$_cp_ss_desired" | grep -Fqx "$_cp_ss_b"; then
@@ -266,9 +262,9 @@ _cp_skills_sync_one() {
         _cp_ss_dst="${_cp_ss_sdir}/${_cp_ss_want}"
         if [ -L "$_cp_ss_dst" ]; then
             _cp_ss_t=$(_cp_link_target "$_cp_ss_dst")
-            case "$_cp_ss_t" in
-                "$_cp_ss_pool"/*) continue ;;
-            esac
+            if _cp_target_in_pool "$_cp_ss_t" "$_cp_ss_pool"; then
+                continue
+            fi
             _cp_die "skill '${_cp_ss_want}': unmanaged entry already at ${_cp_ss_dst}; skipping"
             continue
         fi
@@ -1439,10 +1435,11 @@ SETTINGSEOF
                             _cp_sk_status="dangling (target missing)"
                         elif [ -L "$_cp_sk_dst" ]; then
                             _cp_sk_t=$(_cp_link_target "$_cp_sk_dst") || _cp_sk_t=""
-                            case "$_cp_sk_t" in
-                                "$_cp_sk_pool"/*) _cp_sk_status="linked" ;;
-                                *) _cp_sk_status="conflict (unmanaged entry)" ;;
-                            esac
+                            if _cp_target_in_pool "$_cp_sk_t" "$_cp_sk_pool"; then
+                                _cp_sk_status="linked"
+                            else
+                                _cp_sk_status="conflict (unmanaged entry)"
+                            fi
                         elif [ -e "$_cp_sk_dst" ]; then
                             _cp_sk_status="conflict (unmanaged entry)"
                         elif printf '%s\n' "$_cp_sk_desired" | grep -Fqx "$_cp_sk_n"; then

--- a/claude-profile.sh
+++ b/claude-profile.sh
@@ -178,6 +178,8 @@ _cp_read_manifest() {
 # can report them and sync can warn.
 _cp_pool_skills() {
     [ -d "$1" ] || return 0
+    # The ls guard keeps zsh's nomatch from aborting on an empty glob.
+    [ -n "$(ls "$1" 2>/dev/null)" ] || return 0
     for _cp_ps_e in "$1"/*; do
         [ -d "$_cp_ps_e" ] || [ -L "$_cp_ps_e" ] || continue
         printf '%s\n' "${_cp_ps_e##*/}"
@@ -214,7 +216,8 @@ _cp_skills_sync_one() {
     mkdir -p "$_cp_ss_sdir" 2>/dev/null || { _cp_die "cannot create ${_cp_ss_sdir}"; return 1; }
 
     # Pass 1: drop managed links that are dangling or no longer desired.
-    for _cp_ss_e in "$_cp_ss_sdir"/*; do
+    # The ls guard keeps zsh's nomatch from aborting on an empty glob.
+    [ -n "$(ls "$_cp_ss_sdir" 2>/dev/null)" ] && for _cp_ss_e in "$_cp_ss_sdir"/*; do
         [ -e "$_cp_ss_e" ] || [ -L "$_cp_ss_e" ] || continue
         [ -L "$_cp_ss_e" ] || continue
         _cp_ss_t=$(_cp_link_target "$_cp_ss_e") || continue
@@ -1356,7 +1359,9 @@ SETTINGSEOF
                         return 1
                     fi
                     if [ "${1:-}" = "--all" ]; then
-                        for _cp_sk_p in "$_cp_data"/*/; do
+                        # The ls guard keeps zsh's nomatch from aborting on
+                        # an empty glob.
+                        [ -n "$(ls "$_cp_data" 2>/dev/null)" ] && for _cp_sk_p in "$_cp_data"/*/; do
                             [ -d "$_cp_sk_p" ] || continue
                             _cp_sk_pn="${_cp_sk_p%/}"
                             _cp_sk_pn="${_cp_sk_pn##*/}"
@@ -1386,7 +1391,9 @@ SETTINGSEOF
                     printf 'Skill pool: %s\n' "$_cp_sk_pool"
                     _cp_sk_desired=$(_cp_desired_skills "$_cp_sk_pdir" "$_cp_sk_pool")
                     _cp_sk_found=0
-                    for _cp_sk_e in "$_cp_sk_pool"/*; do
+                    # The ls guard keeps zsh's nomatch from aborting on an
+                    # empty glob.
+                    [ -n "$(ls "$_cp_sk_pool" 2>/dev/null)" ] && for _cp_sk_e in "$_cp_sk_pool"/*; do
                         [ -d "$_cp_sk_e" ] || [ -L "$_cp_sk_e" ] || continue
                         _cp_sk_found=1
                         _cp_sk_n="${_cp_sk_e##*/}"

--- a/claude-profile.sh
+++ b/claude-profile.sh
@@ -66,7 +66,226 @@ _cp_validate_name() {
             _cp_die "invalid profile name '$1': use only letters, digits, hyphens, underscores"
             return 1
             ;;
+        skills)
+            _cp_die "profile name 'skills' is reserved for the skill pool"
+            return 1
+            ;;
     esac
+}
+
+# --- Skill pool helpers ---
+#
+# A central pool at <data-root>/skills holds registered skills (directories
+# or links to skill source directories). Each profile may carry a
+# skills.conf manifest (one pool-skill name per line, # comments) naming
+# the subset it wants; no manifest means every pool skill. Sync
+# materializes the selection as links in <profile>/skills. Only links
+# whose target lies under the pool are ever created or removed — hand-made
+# links, real directories, and files are left alone.
+
+_cp_validate_skill_name() {
+    case "$1" in
+        "")
+            _cp_die "skill name must not be empty"
+            return 1
+            ;;
+        .*)
+            _cp_die "invalid skill name '$1': must not start with '.'"
+            return 1
+            ;;
+        *..*)
+            _cp_die "invalid skill name '$1': must not contain '..'"
+            return 1
+            ;;
+        */*)
+            _cp_die "invalid skill name '$1': must not contain '/'"
+            return 1
+            ;;
+        *\\*)
+            _cp_die "invalid skill name '$1': must not contain '\\'"
+            return 1
+            ;;
+    esac
+    case "$1" in
+        *[!A-Za-z0-9_-]*)
+            _cp_die "invalid skill name '$1': use only letters, digits, hyphens, underscores"
+            return 1
+            ;;
+    esac
+}
+
+# Prints the literal target of link $1 (fails if not a link). On MSYS the
+# junction target may come back as a Windows path; normalize via cygpath
+# so prefix comparison against the pool directory works.
+_cp_link_target() {
+    _cp_lt_t=$(readlink "$1" 2>/dev/null) || return 1
+    [ -n "$_cp_lt_t" ] || return 1
+    if _cp_is_msys && command -v cygpath >/dev/null 2>&1; then
+        case "$_cp_lt_t" in
+            [A-Za-z]:*|*\\*) _cp_lt_t=$(cygpath -u "$_cp_lt_t" 2>/dev/null) ;;
+        esac
+    fi
+    printf '%s\n' "$_cp_lt_t"
+}
+
+# Creates a link at $2 pointing to directory $1. Uses a directory junction
+# on MSYS (no admin rights needed, readable by the cmd and PowerShell
+# implementations), a plain symlink everywhere else.
+_cp_make_link() {
+    if _cp_is_msys && command -v cygpath >/dev/null 2>&1; then
+        _cp_ml_src=$(cygpath -w "$1" 2>/dev/null) || _cp_ml_src=""
+        _cp_ml_dst=$(cygpath -w "$2" 2>/dev/null) || _cp_ml_dst=""
+        if [ -n "$_cp_ml_src" ] && [ -n "$_cp_ml_dst" ]; then
+            cmd //c mklink /J "$_cp_ml_dst" "$_cp_ml_src" >/dev/null 2>&1 && return 0
+        fi
+        return 1
+    fi
+    ln -s "$1" "$2" 2>/dev/null
+}
+
+# Removes a link without touching its target (junctions need rmdir).
+_cp_remove_link() {
+    rm -f "$1" 2>/dev/null || rmdir "$1" 2>/dev/null
+}
+
+# Prints the valid skill names from manifest file $1, one per line.
+# Blank lines and # comments are skipped; invalid names warn and are
+# skipped so one bad line never fails a whole sync.
+_cp_read_manifest() {
+    while IFS= read -r _cp_rm_line || [ -n "$_cp_rm_line" ]; do
+        _cp_rm_line="${_cp_rm_line%"$_CP_CR"}"
+        while :; do
+            case "$_cp_rm_line" in
+                " "*|"	"*) _cp_rm_line="${_cp_rm_line#?}" ;;
+                *" "|*"	") _cp_rm_line="${_cp_rm_line%?}" ;;
+                *) break ;;
+            esac
+        done
+        case "$_cp_rm_line" in
+            ''|'#'*) continue ;;
+            .*|*..*|*/*|*\\*|*[!A-Za-z0-9_-]*)
+                _cp_die "skills.conf: ignoring invalid skill name '${_cp_rm_line}'"
+                continue
+                ;;
+        esac
+        printf '%s\n' "$_cp_rm_line"
+    done < "$1"
+    return 0
+}
+
+# Prints the names of every skill registered in pool directory $1.
+# Includes dangling registrations (link whose source is gone) so listings
+# can report them and sync can warn.
+_cp_pool_skills() {
+    [ -d "$1" ] || return 0
+    for _cp_ps_e in "$1"/*; do
+        [ -d "$_cp_ps_e" ] || [ -L "$_cp_ps_e" ] || continue
+        printf '%s\n' "${_cp_ps_e##*/}"
+    done
+    return 0
+}
+
+# Prints the desired skill set for profile directory $1 against pool $2:
+# the manifest names when skills.conf exists, every pool skill otherwise.
+_cp_desired_skills() {
+    if [ -f "$1/skills.conf" ]; then
+        _cp_read_manifest "$1/skills.conf"
+    else
+        _cp_pool_skills "$2"
+    fi
+}
+
+# Ensures profile directory $1 has a concrete skills.conf, materializing
+# the implicit "all pool skills" default first so add/remove edits stay
+# sticky instead of silently narrowing "all" to one skill.
+_cp_skills_materialize_manifest() {
+    [ -f "$1/skills.conf" ] && return 0
+    _cp_pool_skills "${_cp_data}/skills" > "$1/skills.conf"
+}
+
+# Re-materializes managed skill links for profile NAME ($1) from its
+# manifest (or the whole pool when no manifest). Uses $_cp_data.
+_cp_skills_sync_one() {
+    _cp_ss_name="$1"
+    _cp_ss_pool="${_cp_data}/skills"
+    _cp_ss_pdir="${_cp_data}/${_cp_ss_name}"
+    _cp_ss_sdir="${_cp_ss_pdir}/skills"
+    _cp_ss_desired=$(_cp_desired_skills "$_cp_ss_pdir" "$_cp_ss_pool")
+    mkdir -p "$_cp_ss_sdir" 2>/dev/null || { _cp_die "cannot create ${_cp_ss_sdir}"; return 1; }
+
+    # Pass 1: drop managed links that are dangling or no longer desired.
+    for _cp_ss_e in "$_cp_ss_sdir"/*; do
+        [ -e "$_cp_ss_e" ] || [ -L "$_cp_ss_e" ] || continue
+        [ -L "$_cp_ss_e" ] || continue
+        _cp_ss_t=$(_cp_link_target "$_cp_ss_e") || continue
+        case "$_cp_ss_t" in
+            "$_cp_ss_pool"/*) ;;
+            *) continue ;;
+        esac
+        _cp_ss_b="${_cp_ss_e##*/}"
+        if [ ! -d "${_cp_ss_pool}/${_cp_ss_b}" ] \
+            || ! printf '%s\n' "$_cp_ss_desired" | grep -Fqx "$_cp_ss_b"; then
+            _cp_remove_link "$_cp_ss_e" || _cp_die "could not remove ${_cp_ss_e}"
+        fi
+    done
+
+    # Pass 2: create links missing from the desired set.
+    [ -n "$_cp_ss_desired" ] || return 0
+    printf '%s\n' "$_cp_ss_desired" | while IFS= read -r _cp_ss_want; do
+        [ -n "$_cp_ss_want" ] || continue
+        if [ ! -d "${_cp_ss_pool}/${_cp_ss_want}" ]; then
+            _cp_die "skill '${_cp_ss_want}' is not in the pool (or its source is gone); skipping"
+            continue
+        fi
+        _cp_ss_dst="${_cp_ss_sdir}/${_cp_ss_want}"
+        if [ -L "$_cp_ss_dst" ]; then
+            _cp_ss_t=$(_cp_link_target "$_cp_ss_dst")
+            case "$_cp_ss_t" in
+                "$_cp_ss_pool"/*) continue ;;
+            esac
+            _cp_die "skill '${_cp_ss_want}': unmanaged entry already at ${_cp_ss_dst}; skipping"
+            continue
+        fi
+        if [ -e "$_cp_ss_dst" ]; then
+            _cp_die "skill '${_cp_ss_want}': unmanaged entry already at ${_cp_ss_dst}; skipping"
+            continue
+        fi
+        _cp_make_link "${_cp_ss_pool}/${_cp_ss_want}" "$_cp_ss_dst" \
+            || _cp_die "could not link skill '${_cp_ss_want}'"
+    done
+    return 0
+}
+
+# Resolves the profile a skills command acts on into _cp_sp_name: the
+# explicit argument $1 if given, else the active profile, else the
+# default. Uses $_cp_data / $_cp_default_file.
+_cp_skills_profile() {
+    if [ -n "${1:-}" ]; then
+        _cp_validate_name "$1" || return 1
+        _cp_sp_name="$1"
+    elif [ -n "${CLAUDE_CONFIG_DIR:-}" ]; then
+        case "$CLAUDE_CONFIG_DIR" in
+            "${_cp_data}"/*) _cp_sp_name="${CLAUDE_CONFIG_DIR##*/}" ;;
+            *)
+                _cp_die "active CLAUDE_CONFIG_DIR is not a managed profile; pass a profile name"
+                return 1
+                ;;
+        esac
+    elif [ -f "$_cp_default_file" ]; then
+        _cp_sp_name=$(cat "$_cp_default_file")
+        if [ -z "$_cp_sp_name" ]; then
+            _cp_die "no profile specified and no default profile set"
+            return 1
+        fi
+    else
+        _cp_die "no profile specified and no default profile set"
+        return 1
+    fi
+    if [ ! -d "${_cp_data}/${_cp_sp_name}" ]; then
+        _cp_die "profile '${_cp_sp_name}' does not exist"
+        return 1
+    fi
+    return 0
 }
 
 # --- Version tracking helpers ---
@@ -508,7 +727,7 @@ _cp_auto_switch() {
     fi
 
     case "$_cp_dotname" in
-        .*|*..*|*/*|*\\*|*[!A-Za-z0-9_-]*)
+        skills|.*|*..*|*/*|*\\*|*[!A-Za-z0-9_-]*)
             _cp_die "ignoring ${_cp_dotfile}: invalid profile name '${_cp_dotname}'"
             return 1
             ;;
@@ -759,6 +978,11 @@ claude-profile() {
             mkdir -p "$_cp_dir"
             printf 'Created profile: %s\n' "$_cp_name"
             printf 'Config directory: %s\n' "$_cp_dir"
+            # A new profile has no manifest, so this links every pool skill
+            # (the backward-compatible "all" default). No pool: no-op.
+            if [ -d "${_cp_data}/skills" ]; then
+                _cp_skills_sync_one "$_cp_name"
+            fi
             if [ "$_cp_do_init" -eq 1 ]; then
                 _cp_settings="${_cp_dir}/settings.json"
                 cat > "$_cp_settings" <<'SETTINGSEOF'
@@ -815,10 +1039,17 @@ SETTINGSEOF
                 esac
             fi
             _cp_found=0
+            _cp_pool_n=$(_cp_pool_skills "${_cp_data}/skills" | grep -c .)
             for _cp_entry in "$_cp_data"/*/; do
                 [ -d "$_cp_entry" ] || continue
                 _cp_entry_name=$(basename "$_cp_entry")
+                [ "$_cp_entry_name" = "skills" ] && continue
                 _cp_found=1
+                _cp_sk_note=""
+                if [ -f "${_cp_entry%/}/skills.conf" ]; then
+                    _cp_sk_n=$(_cp_read_manifest "${_cp_entry%/}/skills.conf" 2>/dev/null | grep -c .)
+                    _cp_sk_note=" [skills: ${_cp_sk_n}/${_cp_pool_n}]"
+                fi
                 _cp_is_default=0
                 _cp_is_active=0
                 if [ "$_cp_entry_name" = "$_cp_cur_default" ]; then
@@ -828,13 +1059,13 @@ SETTINGSEOF
                     _cp_is_active=1
                 fi
                 if [ "$_cp_is_default" -eq 1 ] && [ "$_cp_is_active" -eq 1 ]; then
-                    printf '>* %s (default, active)\n' "$_cp_entry_name"
+                    printf '>* %s (default, active)%s\n' "$_cp_entry_name" "$_cp_sk_note"
                 elif [ "$_cp_is_default" -eq 1 ]; then
-                    printf ' * %s (default)\n' "$_cp_entry_name"
+                    printf ' * %s (default)%s\n' "$_cp_entry_name" "$_cp_sk_note"
                 elif [ "$_cp_is_active" -eq 1 ]; then
-                    printf '>  %s (active)\n' "$_cp_entry_name"
+                    printf '>  %s (active)%s\n' "$_cp_entry_name" "$_cp_sk_note"
                 else
-                    printf '   %s\n' "$_cp_entry_name"
+                    printf '   %s%s\n' "$_cp_entry_name" "$_cp_sk_note"
                 fi
             done
             if [ "$_cp_found" -eq 0 ]; then
@@ -940,6 +1171,254 @@ SETTINGSEOF
             esac
             ;;
 
+        skills)
+            shift
+            _cp_sk_pool="${_cp_data}/skills"
+            case "${1:-}" in
+                register)
+                    shift
+                    _cp_sk_name="${1:-}"
+                    _cp_sk_path="${2:-}"
+                    if [ -z "$_cp_sk_name" ] || [ -z "$_cp_sk_path" ]; then
+                        _cp_die "usage: claude-profile skills register <name> <path>"
+                        return 1
+                    fi
+                    if [ -n "${3:-}" ]; then
+                        _cp_die "unexpected argument '$3'"
+                        return 1
+                    fi
+                    _cp_validate_skill_name "$_cp_sk_name" || return 1
+                    if [ ! -d "$_cp_sk_path" ]; then
+                        _cp_die "'${_cp_sk_path}' is not a directory"
+                        return 1
+                    fi
+                    if [ ! -f "${_cp_sk_path}/SKILL.md" ]; then
+                        _cp_die "'${_cp_sk_path}' does not contain a SKILL.md"
+                        return 1
+                    fi
+                    mkdir -p "$_cp_sk_pool" || { _cp_die "cannot create ${_cp_sk_pool}"; return 1; }
+                    if [ -e "${_cp_sk_pool}/${_cp_sk_name}" ] || [ -L "${_cp_sk_pool}/${_cp_sk_name}" ]; then
+                        _cp_die "skill '${_cp_sk_name}' is already registered"
+                        return 1
+                    fi
+                    _cp_sk_abs=$(CDPATH='' cd -- "$_cp_sk_path" 2>/dev/null && pwd) || _cp_sk_abs=""
+                    if [ -z "$_cp_sk_abs" ]; then
+                        _cp_die "could not resolve '${_cp_sk_path}' to an absolute path"
+                        return 1
+                    fi
+                    if ! _cp_make_link "$_cp_sk_abs" "${_cp_sk_pool}/${_cp_sk_name}"; then
+                        _cp_die "could not create pool link for '${_cp_sk_name}'"
+                        return 1
+                    fi
+                    printf 'Registered skill: %s -> %s\n' "$_cp_sk_name" "$_cp_sk_abs"
+                    printf "Run 'claude-profile skills sync --all' to link it into unfiltered profiles.\\n"
+                    ;;
+
+                unregister)
+                    shift
+                    _cp_sk_force=0
+                    _cp_sk_name=""
+                    while [ $# -gt 0 ]; do
+                        case "$1" in
+                            --force) _cp_sk_force=1 ;;
+                            -*)
+                                _cp_die "unknown option '$1'"
+                                return 1
+                                ;;
+                            *)
+                                if [ -n "$_cp_sk_name" ]; then
+                                    _cp_die "unexpected argument '$1'"
+                                    return 1
+                                fi
+                                _cp_sk_name="$1"
+                                ;;
+                        esac
+                        shift
+                    done
+                    if [ -z "$_cp_sk_name" ]; then
+                        _cp_die "usage: claude-profile skills unregister [--force] <name>"
+                        return 1
+                    fi
+                    _cp_validate_skill_name "$_cp_sk_name" || return 1
+                    _cp_sk_entry="${_cp_sk_pool}/${_cp_sk_name}"
+                    if [ -L "$_cp_sk_entry" ]; then
+                        _cp_remove_link "$_cp_sk_entry" || { _cp_die "could not remove ${_cp_sk_entry}"; return 1; }
+                    elif [ -d "$_cp_sk_entry" ]; then
+                        if [ "$_cp_sk_force" -eq 0 ]; then
+                            _cp_die "'${_cp_sk_name}' is a real directory in the pool; pass --force to delete it and its contents"
+                            return 1
+                        fi
+                        rm -rf "$_cp_sk_entry" || { _cp_die "could not remove ${_cp_sk_entry}"; return 1; }
+                    else
+                        _cp_die "skill '${_cp_sk_name}' is not registered"
+                        return 1
+                    fi
+                    for _cp_sk_p in "$_cp_data"/*/; do
+                        [ -d "$_cp_sk_p" ] || continue
+                        _cp_sk_pn="${_cp_sk_p%/}"
+                        _cp_sk_pn="${_cp_sk_pn##*/}"
+                        [ "$_cp_sk_pn" = "skills" ] && continue
+                        if [ -f "${_cp_sk_p%/}/skills.conf" ] \
+                            && grep -qx "$_cp_sk_name" "${_cp_sk_p%/}/skills.conf" 2>/dev/null; then
+                            _cp_die "note: profile '${_cp_sk_pn}' still lists '${_cp_sk_name}' in skills.conf"
+                        fi
+                    done
+                    printf 'Unregistered skill: %s\n' "$_cp_sk_name"
+                    printf "Run 'claude-profile skills sync --all' to remove stale links from profiles.\\n"
+                    ;;
+
+                add|remove)
+                    _cp_sk_op="$1"
+                    shift
+                    _cp_sk_name="${1:-}"
+                    if [ -z "$_cp_sk_name" ]; then
+                        _cp_die "usage: claude-profile skills ${_cp_sk_op} <skill> [profile]"
+                        return 1
+                    fi
+                    if [ -n "${3:-}" ]; then
+                        _cp_die "unexpected argument '$3'"
+                        return 1
+                    fi
+                    _cp_validate_skill_name "$_cp_sk_name" || return 1
+                    _cp_skills_profile "${2:-}" || return 1
+                    _cp_sk_pdir="${_cp_data}/${_cp_sp_name}"
+                    if [ "$_cp_sk_op" = "add" ] && [ ! -d "${_cp_sk_pool}/${_cp_sk_name}" ]; then
+                        _cp_die "skill '${_cp_sk_name}' is not in the pool. Register it with: claude-profile skills register ${_cp_sk_name} <path>"
+                        return 1
+                    fi
+                    _cp_skills_materialize_manifest "$_cp_sk_pdir" || { _cp_die "could not write skills.conf"; return 1; }
+                    _cp_sk_file="${_cp_sk_pdir}/skills.conf"
+                    if [ "$_cp_sk_op" = "add" ]; then
+                        if ! grep -qx "$_cp_sk_name" "$_cp_sk_file" 2>/dev/null; then
+                            printf '%s\n' "$_cp_sk_name" >> "$_cp_sk_file" || return 1
+                        fi
+                        _cp_skills_sync_one "$_cp_sp_name" || return 1
+                        printf "Added skill '%s' to profile '%s'\n" "$_cp_sk_name" "$_cp_sp_name"
+                    else
+                        grep -vx "$_cp_sk_name" "$_cp_sk_file" > "${_cp_sk_file}.tmp.$$" 2>/dev/null
+                        mv -f "${_cp_sk_file}.tmp.$$" "$_cp_sk_file" || { rm -f "${_cp_sk_file}.tmp.$$"; return 1; }
+                        _cp_skills_sync_one "$_cp_sp_name" || return 1
+                        printf "Removed skill '%s' from profile '%s'\n" "$_cp_sk_name" "$_cp_sp_name"
+                    fi
+                    ;;
+
+                set)
+                    shift
+                    _cp_sk_list="${1:-}"
+                    if [ -z "$_cp_sk_list" ]; then
+                        _cp_die "usage: claude-profile skills set <skill1,skill2,...> [profile]"
+                        return 1
+                    fi
+                    if [ -n "${3:-}" ]; then
+                        _cp_die "unexpected argument '$3'"
+                        return 1
+                    fi
+                    _cp_skills_profile "${2:-}" || return 1
+                    _cp_sk_file="${_cp_data}/${_cp_sp_name}/skills.conf"
+                    _cp_sk_tmp="${_cp_sk_file}.tmp.$$"
+                    : > "$_cp_sk_tmp" || { _cp_die "could not write skills.conf"; return 1; }
+                    _cp_sk_old_ifs="$IFS"
+                    IFS=','
+                    set -f
+                    # shellcheck disable=SC2086  # word splitting on commas is the point
+                    set -- $_cp_sk_list
+                    set +f
+                    IFS="$_cp_sk_old_ifs"
+                    for _cp_sk_name in "$@"; do
+                        [ -n "$_cp_sk_name" ] || continue
+                        _cp_validate_skill_name "$_cp_sk_name" || { rm -f "$_cp_sk_tmp"; return 1; }
+                        if [ ! -d "${_cp_sk_pool}/${_cp_sk_name}" ]; then
+                            _cp_die "warning: skill '${_cp_sk_name}' is not in the pool"
+                        fi
+                        printf '%s\n' "$_cp_sk_name" >> "$_cp_sk_tmp"
+                    done
+                    mv -f "$_cp_sk_tmp" "$_cp_sk_file" || { rm -f "$_cp_sk_tmp"; return 1; }
+                    _cp_skills_sync_one "$_cp_sp_name" || return 1
+                    printf "Set skills for profile '%s'\n" "$_cp_sp_name"
+                    ;;
+
+                reset)
+                    shift
+                    if [ -n "${2:-}" ]; then
+                        _cp_die "unexpected argument '$2'"
+                        return 1
+                    fi
+                    _cp_skills_profile "${1:-}" || return 1
+                    rm -f "${_cp_data}/${_cp_sp_name}/skills.conf"
+                    _cp_skills_sync_one "$_cp_sp_name" || return 1
+                    printf "Profile '%s' reset to all pool skills\n" "$_cp_sp_name"
+                    ;;
+
+                sync)
+                    shift
+                    if [ -n "${2:-}" ]; then
+                        _cp_die "unexpected argument '$2'"
+                        return 1
+                    fi
+                    if [ "${1:-}" = "--all" ]; then
+                        for _cp_sk_p in "$_cp_data"/*/; do
+                            [ -d "$_cp_sk_p" ] || continue
+                            _cp_sk_pn="${_cp_sk_p%/}"
+                            _cp_sk_pn="${_cp_sk_pn##*/}"
+                            [ "$_cp_sk_pn" = "skills" ] && continue
+                            _cp_skills_sync_one "$_cp_sk_pn"
+                            printf "Synced profile '%s'\n" "$_cp_sk_pn"
+                        done
+                    else
+                        _cp_skills_profile "${1:-}" || return 1
+                        _cp_skills_sync_one "$_cp_sp_name" || return 1
+                        printf "Synced profile '%s'\n" "$_cp_sp_name"
+                    fi
+                    ;;
+
+                "")
+                    if [ ! -d "$_cp_sk_pool" ]; then
+                        printf 'No skill pool yet. Register a skill with: claude-profile skills register <name> <path>\n'
+                        return 0
+                    fi
+                    _cp_skills_profile "" || return 1
+                    _cp_sk_pdir="${_cp_data}/${_cp_sp_name}"
+                    if [ -f "${_cp_sk_pdir}/skills.conf" ]; then
+                        printf "Profile '%s': skills.conf present (filtered)\n" "$_cp_sp_name"
+                    else
+                        printf "Profile '%s': no skills.conf (all pool skills)\n" "$_cp_sp_name"
+                    fi
+                    printf 'Skill pool: %s\n' "$_cp_sk_pool"
+                    _cp_sk_desired=$(_cp_desired_skills "$_cp_sk_pdir" "$_cp_sk_pool")
+                    _cp_sk_found=0
+                    for _cp_sk_e in "$_cp_sk_pool"/*; do
+                        [ -d "$_cp_sk_e" ] || [ -L "$_cp_sk_e" ] || continue
+                        _cp_sk_found=1
+                        _cp_sk_n="${_cp_sk_e##*/}"
+                        _cp_sk_dst="${_cp_sk_pdir}/skills/${_cp_sk_n}"
+                        _cp_sk_status="not linked"
+                        if [ ! -d "$_cp_sk_e" ]; then
+                            _cp_sk_status="dangling (target missing)"
+                        elif [ -L "$_cp_sk_dst" ]; then
+                            _cp_sk_t=$(_cp_link_target "$_cp_sk_dst") || _cp_sk_t=""
+                            case "$_cp_sk_t" in
+                                "$_cp_sk_pool"/*) _cp_sk_status="linked" ;;
+                                *) _cp_sk_status="conflict (unmanaged entry)" ;;
+                            esac
+                        elif [ -e "$_cp_sk_dst" ]; then
+                            _cp_sk_status="conflict (unmanaged entry)"
+                        elif printf '%s\n' "$_cp_sk_desired" | grep -Fqx "$_cp_sk_n"; then
+                            _cp_sk_status="selected, not linked (run sync)"
+                        fi
+                        printf '  %-24s %s\n' "$_cp_sk_n" "$_cp_sk_status"
+                    done
+                    if [ "$_cp_sk_found" -eq 0 ]; then
+                        printf '  (pool is empty)\n'
+                    fi
+                    ;;
+
+                *)
+                    _cp_die "unknown skills command '$1'. Run 'claude-profile help' for usage."
+                    return 1
+                    ;;
+            esac
+            ;;
+
         version)
             _cp_installed_version
             ;;
@@ -963,6 +1442,20 @@ Commands:
                             directory-local profile for the current directory
     auto [on|off|status]    Control directory-local auto-switching
     which [name]            Show the resolved config directory path
+    skills                  List pool skills and their status for the profile
+    skills register <name> <path>
+                            Add a skill directory to the shared pool
+    skills unregister [--force] <name>
+                            Remove a skill from the pool
+    skills add <skill> [profile]
+                            Add a pool skill to a profile
+    skills remove <skill> [profile]
+                            Remove a pool skill from a profile
+    skills set <s1,s2,...> [profile]
+                            Replace a profile's skill selection
+    skills reset [profile]  Back to the default (all pool skills)
+    skills sync [profile|--all]
+                            Re-materialize skill links
     version                 Show the installed version
     update [--force]        Update to the latest release
     delete <name>           Delete a profile
@@ -978,9 +1471,16 @@ explicit 'claude-profile use' pins the session and wins over any
 CLAUDE_PROFILE_NO_AUTO_SWITCH=1 to disable, CLAUDE_PROFILE_AUTO_QUIET=1
 to switch silently.
 
+Skills: a shared pool at <data-dir>/skills holds registered skills. A
+profile's skills.conf (one name per line, # comments) selects the subset
+linked into <profile>/skills; without one the profile gets every pool
+skill. Hand-made entries in <profile>/skills are never touched.
+
 Examples:
     claude-profile create work
     claude-profile create --init work
+    claude-profile skills register humanize ~/skills/humanize
+    claude-profile skills set humanize,optimize work
     claude-profile default work
     claude-profile use work
     claude                          # runs with "work" profile
@@ -1020,6 +1520,21 @@ HELPEOF
                 printf 'Default profile: %s\n' "$_cp_cur_default"
             else
                 printf 'No default profile set\n'
+            fi
+            # Skills annotation for the active (else default) profile;
+            # silent until a skill pool exists.
+            if [ -d "${_cp_data}/skills" ]; then
+                _cp_sk_prof="$_cp_active"
+                [ -n "$_cp_sk_prof" ] || _cp_sk_prof="$_cp_cur_default"
+                if [ -n "$_cp_sk_prof" ] && [ -d "${_cp_data}/${_cp_sk_prof}" ]; then
+                    _cp_sk_pool_n=$(_cp_pool_skills "${_cp_data}/skills" | grep -c .)
+                    if [ -f "${_cp_data}/${_cp_sk_prof}/skills.conf" ]; then
+                        _cp_sk_n=$(_cp_read_manifest "${_cp_data}/${_cp_sk_prof}/skills.conf" 2>/dev/null | grep -c .)
+                        printf 'Skills: %s of %s pool skills (filtered)\n' "$_cp_sk_n" "$_cp_sk_pool_n"
+                    else
+                        printf 'Skills: all pool skills (%s)\n' "$_cp_sk_pool_n"
+                    fi
+                fi
             fi
             ;;
 

--- a/docs/superpowers/specs/2026-08-18-profile-skills-design.md
+++ b/docs/superpowers/specs/2026-08-18-profile-skills-design.md
@@ -1,0 +1,148 @@
+# Profile Skill Pools — Design Spec
+
+Date: 2026-08-18
+Status: Approved (Approach A: manifest + symlinks)
+
+## Problem
+
+Skills are hand-curated per profile today: each profile's `skills/`
+directory is a manually maintained farm of symlinks into skill source
+repos. There is no shared registry of available skills, no declarative
+record of which skills a profile should have, and no tooling to add,
+remove, or re-sync them. The goal is managed curation: a central pool
+of registered skills, a per-profile manifest selecting a subset, and
+commands to materialize that selection as links.
+
+## Data model
+
+```
+<data-root>/                          # $XDG_DATA_HOME/claude-profiles/ or %LOCALAPPDATA%\claude-profiles\
+├── skills/                           # NEW: central pool
+│   ├── humanize -> <source path>     # registered as symlink/junction, or a real directory
+│   └── ...
+├── <profile>/
+│   ├── skills/                       # managed links into the pool + untouched manual entries
+│   └── skills.conf                   # NEW: optional manifest
+```
+
+### Pool
+
+- Located at `<data-root>/skills/`. Created on demand.
+- Entries are directories or links to directories. `skills register`
+  creates a symlink (POSIX) or directory junction (Windows, no admin
+  required) pointing at a user-supplied source path, which must
+  contain a `SKILL.md`.
+- Pool entry names follow the existing profile-name validation:
+  `[A-Za-z0-9_-]+`, no leading `.`, no `/`, `\`, or `..`.
+
+### Manifest (`<profile>/skills.conf`)
+
+- Plain text, one pool-skill name per line. Blank lines and lines
+  starting with `#` are ignored (same parser style as
+  `.claude-profile`).
+- **File absent** = profile gets **all** pool skills (backward
+  compatible default).
+- **File present but empty** (or only comments) = explicitly **no**
+  pool skills.
+- Names are validated with the same rule as pool entries; invalid
+  lines are skipped with a warning.
+
+### Managed vs unmanaged entries
+
+- A link in `<profile>/skills/` is **managed** iff its literal link
+  target resolves under the pool directory. Only one level of linking
+  is ever created by the tool, so a prefix comparison of the literal
+  target against the pool path suffices — no recursive resolution.
+- Sync creates and removes managed links only. Hand-made symlinks,
+  real directories, and files are never touched.
+- If a manifest entry collides with an unmanaged entry of the same
+  name, the unmanaged entry wins; sync warns and skips.
+
+## Command surface
+
+Identical across `claude-profile.sh`, `claude-profile-init.ps1`, and
+`claude-profile.cmd`:
+
+| Command | Behavior |
+|---|---|
+| `claude-profile skills` | List pool skills with status for the target profile: `linked`, `not linked`, or `conflict` (unmanaged entry shadows the name). |
+| `claude-profile skills register <name> <path>` | Add `<path>` to the pool as `<name>` (symlink/junction). `<path>` must exist and contain `SKILL.md`. Fails if `<name>` already exists in the pool. |
+| `claude-profile skills unregister <name>` | Remove `<name>` from the pool. Warns for each profile whose manifest still references it (manifests are not edited). Refuses to delete a real (non-link) directory without `--force`. |
+| `claude-profile skills add <skill> [profile]` | Append to the manifest and link immediately. If the manifest is absent (= all), it is first written out as the full current pool list so the "all" semantics stay sticky, then `<skill>` is added. |
+| `claude-profile skills remove <skill> [profile]` | Remove from the manifest (materializing it first, as with `add`) and unlink. |
+| `claude-profile skills set <s1,s2,...> [profile]` | Replace the manifest wholesale, then sync. |
+| `claude-profile skills reset [profile]` | Delete the manifest (back to "all") and sync. |
+| `claude-profile skills sync [profile\|--all]` | Re-materialize managed links from manifest/pool state. |
+
+- `[profile]` defaults to the active profile if set, else the default
+  profile. `sync --all` iterates every profile directory.
+- Sync algorithm: desired set = manifest names present in the pool
+  (or the whole pool when no manifest) → delete managed links that
+  are dangling or not in the desired set → create missing links.
+  Manifest names absent from the pool produce a warning, never a
+  failure.
+
+## Touch points with existing behavior
+
+- `claude-profile create` runs a sync at the end: with no manifest
+  and a non-empty pool the new profile links every pool skill; with
+  no pool it is a no-op (current behavior preserved).
+- `claude-profile delete` is unchanged — the manifest lives inside
+  the profile directory and is removed with it.
+- `use` and directory-local auto-switching are untouched: profile
+  switching remains a pure environment-variable change with no
+  filesystem work on the bash per-prompt hot path.
+- `claude-profile` (status) and `list` gain a skills annotation:
+  `skills: all` (no manifest) or `skills: N/M (filtered)`.
+- `help` documents the new subcommands.
+
+## Per-implementation notes
+
+- **POSIX sh** (`claude-profile.sh`): `ln -s` for links. Strict
+  POSIX (no `local`, no arrays, `_cp_` variable prefix, `return` not
+  `exit`). On MSYS2/Git Bash (`$MSYSTEM` set), link creation is
+  delegated to `cmd //c mklink /J` with `cygpath -w` paths so links
+  are junctions readable by the cmd and PowerShell implementations.
+  Managed-link detection on MSYS2 compares the junction target (via
+  `cygpath -u` of the reparse target as reported by `readlink` on
+  MSYS, falling back to `cmd //c dir` parsing only if needed).
+- **PowerShell** (`claude-profile-init.ps1`): `New-Item -ItemType
+  Junction` on Windows, `-ItemType SymbolicLink` elsewhere. Managed
+  detection via the item's `LinkType`/`Target` properties. Manual
+  `$args` parsing consistent with the rest of the file.
+- **cmd** (`claude-profile.cmd`): `mklink /J` for pool and profile
+  links, `rmdir` to remove a junction without touching its target.
+  Managed detection parses `dir /AL` output for the `[target]`
+  suffix and prefix-compares against the pool path. Same `goto`
+  dispatch and `setlocal enabledelayedexpansion` idiom.
+
+## Error handling
+
+- All validation errors print to stderr and return non-zero without
+  partial writes where feasible; sync is idempotent so a re-run
+  repairs any interrupted state.
+- Dangling pool registrations (source path deleted) are reported by
+  `skills` listing and cleaned from profiles by `sync` (the managed
+  link is removed when its pool entry no longer resolves).
+
+## Testing
+
+Manual verification matrix (project has no test framework):
+
+1. `register` / `unregister` (link + real-dir + `--force` paths).
+2. `add` / `remove` / `set` / `reset` on profiles with and without an
+   existing manifest.
+3. Absent-manifest default (all pool skills) at `create` and `sync`.
+4. Empty manifest = zero managed links, unmanaged entries preserved.
+5. Unmanaged conflict: hand-made link with a pool name survives sync
+   with a warning.
+6. Dangling pool target cleanup.
+7. Platforms: Linux sh + pwsh; Windows cmd + PowerShell + Git Bash
+   (junction interop between all three).
+8. `shellcheck` and `checkbashisms` clean on `claude-profile.sh`.
+
+## Documentation
+
+README gains a "Per-profile skills" section covering the pool, the
+manifest format and defaults, and the command table. CLAUDE.md's
+command table and architecture notes are updated per repo rules.

--- a/docs/superpowers/specs/2026-08-18-profile-skills-design.md
+++ b/docs/superpowers/specs/2026-08-18-profile-skills-design.md
@@ -34,6 +34,12 @@ commands to materialize that selection as links.
   contain a `SKILL.md`.
 - Pool entry names follow the existing profile-name validation:
   `[A-Za-z0-9_-]+`, no leading `.`, no `/`, `\`, or `..`.
+- The profile name `skills` is reserved (case-insensitively, since the
+  Windows data directory is case-insensitive) in all three validators and
+  in the `.claude-profile` resolvers. If `<data-root>/skills` exists but
+  looks like a pre-reservation profile (contains `settings.json` or
+  `.credentials.json`), every pool operation and sync refuses with an
+  error telling the user to move that profile aside.
 
 ### Manifest (`<profile>/skills.conf`)
 
@@ -44,8 +50,13 @@ commands to materialize that selection as links.
   compatible default).
 - **File present but empty** (or only comments) = explicitly **no**
   pool skills.
+- **File present but unreadable** = error; sync aborts rather than
+  treating it as "select nothing" and stripping the profile's links.
 - Names are validated with the same rule as pool entries; invalid
   lines are skipped with a warning.
+- Manifests may be CRLF (written by the cmd/PowerShell implementations
+  into the shared Windows data directory); all readers and the sh
+  add/remove editors strip CR before comparing.
 
 ### Managed vs unmanaged entries
 
@@ -92,8 +103,10 @@ Identical across `claude-profile.sh`, `claude-profile-init.ps1`, and
 - `use` and directory-local auto-switching are untouched: profile
   switching remains a pure environment-variable change with no
   filesystem work on the bash per-prompt hot path.
-- `claude-profile` (status) and `list` gain a skills annotation:
-  `skills: all` (no manifest) or `skills: N/M (filtered)`.
+- `claude-profile` (status) shows `Skills: all pool skills (M)` or
+  `Skills: N of M pool skills (filtered)` once a pool exists; `list`
+  appends `[skills: N/M]` to profiles that have a manifest (unfiltered
+  profiles stay unannotated to keep the listing quiet).
 - `help` documents the new subcommands.
 
 ## Per-implementation notes
@@ -104,8 +117,11 @@ Identical across `claude-profile.sh`, `claude-profile-init.ps1`, and
   delegated to `cmd //c mklink /J` with `cygpath -w` paths so links
   are junctions readable by the cmd and PowerShell implementations.
   Managed-link detection on MSYS2 compares the junction target (via
-  `cygpath -u` of the reparse target as reported by `readlink` on
-  MSYS, falling back to `cmd //c dir` parsing only if needed).
+  `cygpath -u` of the reparse target as reported by `readlink`). If
+  `readlink` cannot read a junction, the link is treated as unmanaged —
+  a deliberately non-destructive degradation (links are left alone and
+  reported as conflicts) rather than an untestable `cmd //c dir`
+  parsing fallback.
 - **PowerShell** (`claude-profile-init.ps1`): `New-Item -ItemType
   Junction` on Windows, `-ItemType SymbolicLink` elsewhere. Managed
   detection via the item's `LinkType`/`Target` properties. Manual


### PR DESCRIPTION
Closes #7.

Adds a shared skill pool at `<data-root>/skills/` and per-profile `skills.conf` manifests, implemented identically across all three implementations (`claude-profile.sh`, `claude-profile-init.ps1`, `claude-profile.cmd`).

## What's included

- `claude-profile skills register/unregister` — manage the pool (symlinks on POSIX; admin-free directory junctions on Windows, created via `cmd //c mklink /J` + `cygpath` on Git Bash so all three implementations share the same links).
- `claude-profile skills add/remove/set/reset/sync [--all]` — manage per-profile selections.
- **Backward compatible:** no `skills.conf` = the profile gets every pool skill; an empty file = none. `add`/`remove` materialize the implicit "all" list first so edits stay sticky.
- Sync only ever creates/removes links pointing into the pool — hand-made symlinks, real directories, and files in `<profile>/skills/` are never touched; name collisions warn and the unmanaged entry wins.
- No filesystem work on `use` or the directory-local auto-switch hot path; links update only on skills commands and `create`.
- The profile name `skills` is now reserved (case-insensitively); a guard refuses pool operations if a pre-reservation `skills` profile occupies that directory.
- `list`/status annotate filtered profiles (`[skills: N/M]`, `Skills: N of M pool skills (filtered)`).
- Design spec at `docs/superpowers/specs/2026-08-18-profile-skills-design.md`; README and CLAUDE.md updated.

## Verification

- `shellcheck` clean; `checkbashisms` at documented baseline.
- Functional matrix passed on Linux for sh (sh/bash/zsh) and pwsh: register, all/filtered/empty manifests, unmanaged-entry preservation, conflict handling, dangling-target cleanup, CRLF-manifest interop, unreadable-manifest abort, pool guard, reserved names.
- Two independent review passes (critical-reviewer + /code-review); all confirmed findings fixed, including CRLF manifest matching in sh, unreadable-manifest sync abort in all three, and removal of a PS 5.1-unsafe `Remove-Item` junction fallback.
- **Caveat:** `claude-profile.cmd` is code-reviewed but not executed — wine's `findstr` can't run even the shipped v1.2.2 validation regexes, so the batch path should be smoke-tested on a real Windows box before the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)